### PR TITLE
feat: Add production configuration for production

### DIFF
--- a/app-web/src/main/resources/application-production.properties
+++ b/app-web/src/main/resources/application-production.properties
@@ -1,0 +1,40 @@
+# ===============================================================
+# = PRODUCTION DATABASE CONFIGURATION (PostgreSQL)
+# ===============================================================
+# These properties are intended to be overridden by environment variables
+# in your production environment for security reasons.
+# Example environment variables:
+# SPRING_DATASOURCE_URL=jdbc:postgresql://your-prod-db-host:5432/your-db-name
+# SPRING_DATASOURCE_USERNAME=your-prod-db-user
+# SPRING_DATASOURCE_PASSWORD=your-prod-db-password
+
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driverClassName=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# ===============================================================
+# = HIBERNATE/JPA CONFIGURATION
+# ===============================================================
+# 'validate' ensures the database schema matches the entities on startup,
+# which is a safe policy for production. It prevents Hibernate from
+# making unexpected changes to the schema.
+spring.jpa.hibernate.ddl-auto=validate
+
+# Disable verbose SQL logging in production.
+spring.jpa.show-sql=false
+
+# ===============================================================
+# = SECURITY CONFIGURATION
+# ===============================================================
+# Disable H2 console in production for security.
+spring.h2.console.enabled=false
+
+# ===============================================================
+# = LOGGING CONFIGURATION
+# ===============================================================
+# Set the default logging level to INFO for production to avoid
+# excessive logging.
+logging.level.root=INFO
+logging.level.com.tdtsqlscan=INFO


### PR DESCRIPTION
I've added a new `application-production.properties` file to configure the application for a production environment.

This configuration uses PostgreSQL and expects credentials to be provided via environment variables for security. It also sets safer defaults for JPA/Hibernate (ddl-auto=validate) and disables the H2 console.

This prepares the application for the deployment guide I'll be providing to you.