### PR TITLE
Corrige el Dockerfile para el despliegue en Render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,20 @@
 # --- Fase de Construcción (Build Stage) ---
 # Usamos una imagen oficial de Maven con Java 8 para compilar el proyecto.
-# La versión de Java la he deducido de tu archivo pom.xml.
 FROM maven:3.8-openjdk-8 AS build
 
 # Establecemos el directorio de trabajo dentro del contenedor
 WORKDIR /app
 
-# Copiamos los archivos de Maven para descargar dependencias
-COPY .mvn/ .mvn
-COPY mvnw pom.xml ./
-
-# Descargamos las dependencias de Maven. Esto se cachea si no cambian.
-RUN ./mvnw dependency:go-offline
-
-# Copiamos todo el código fuente del proyecto
+# Copiamos todo el código fuente del proyecto primero
 COPY . .
 
-# Compilamos la aplicación y empaquetamos el JAR, saltando los tests
+# Ahora que todos los módulos están presentes, descargamos dependencias y compilamos
+# Unimos dependency:go-offline y package para optimizar
 RUN ./mvnw clean package -DskipTests
 
 
 # --- Fase de Ejecución (Run Stage) ---
-# Usamos una imagen ligera de Java 8 para ejecutar la aplicación, optimizando el tamaño.
+# Usamos una imagen ligera de Java 8 para ejecutar la aplicación
 FROM openjdk:8-jre-slim
 
 # Establecemos el directorio de trabajo
@@ -30,8 +23,8 @@ WORKDIR /app
 # Copiamos solo el JAR compilado desde la fase de construcción
 COPY --from=build /app/app-web/target/app-web-*.jar ./app.jar
 
-# El puerto en el que escuchará la aplicación. Render lo gestionará.
+# El puerto en el que escuchará la aplicación
 EXPOSE 8080
 
-# El comando para arrancar la aplicación, activando el perfil de producción
+# El comando para arrancar la aplicación
 CMD ["java", "-Dspring.profiles.active=production", "-jar", "app.jar"]


### PR DESCRIPTION
El despliegue en Render estaba fallando porque no se encontraban los módulos de Maven durante la fase de construcción.

Este cambio actualiza el Dockerfile para copiar todos los archivos del proyecto antes de ejecutar cualquier comando de Maven. Esto asegura que todos los módulos necesarios estén presentes, solucionando el error de construcción.