### PR TITLE
Corrige el comando RUN en el Dockerfile para evitar errores de Maven

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ WORKDIR /app
 # Copiamos todo el código fuente del proyecto primero
 COPY . .
 
-# Ahora que todos los módulos están presentes, descargamos dependencias y compilamos
-# Unimos dependency:go-offline y package para optimizar
-RUN ./mvnw clean package -DskipTests
+# Ahora que todos los módulos están presentes, compilamos el proyecto.
+# Usamos el "formato exec" para evitar errores de interpretación del shell.
+RUN ["./mvnw", "clean", "package", "-DskipTests"]
 
 
 # --- Fase de Ejecución (Run Stage) ---


### PR DESCRIPTION
Tras el despliegue anterior, surgió un nuevo error de Maven: `Unknown lifecycle phase "/root/.m2"`. Este error suele ocurrir cuando el shell del contenedor interpreta incorrectamente los argumentos del comando.

Este cambio modifica el comando `RUN ./mvnw ...` al "formato exec" (`RUN ["./mvnw", ...]`). Este formato evita la invocación de un shell, pasando los argumentos directamente al ejecutable y solucionando el problema de interpretación.