### PR TITLE
Refactor(docker): Usar mvn en lugar de mvnw para el build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /app
 COPY . .
 
 # Ahora que todos los módulos están presentes, compilamos el proyecto.
-# Usamos el "formato exec" para evitar errores de interpretación del shell.
-RUN ["./mvnw", "clean", "package", "-DskipTests"]
+# Usamos el comando 'mvn' de la imagen base para mayor robustez.
+RUN ["mvn", "clean", "package", "-DskipTests"]
 
 
 # --- Fase de Ejecución (Run Stage) ---


### PR DESCRIPTION
El build en Docker seguía fallando con el error `Unknown lifecycle phase "/root/.m2"`. Este error sugiere que el wrapper de Maven (`mvnw`) está interactuando de forma incorrecta con el entorno de construcción.

Para solucionar el problema de raíz y hacer el build más robusto, este cambio reemplaza la llamada al wrapper `./mvnw` por el comando `mvn` provisto por la imagen base `maven:3.8-openjdk-8`.

Este enfoque es el estándar para construir aplicaciones Maven en Docker, ya que elimina la capa de abstracción del wrapper, que es innecesaria y puede ser una fuente de errores cuando ya se está en un entorno Maven pre-configurado.