### PR TITLE
Fix(runtime): Añadir dependencia del driver de PostgreSQL

### DIFF
--- a/app-web/pom.xml
+++ b/app-web/pom.xml
@@ -56,6 +56,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.tdtsqlscan</groupId>
             <artifactId>parser-etl</artifactId>
             <version>1.0.0-SNAPSHOT</version>


### PR DESCRIPTION
El despliegue fallaba en el arranque de la aplicación con el error `Cannot load driver class: org.postgresql.Driver`.

Este error se debía a que la dependencia del driver JDBC de PostgreSQL no estaba incluida en el artefacto final.

Este cambio añade la dependencia `org.postgresql:postgresql` con el scope `runtime` al módulo `app-web`, asegurando que el driver esté disponible en el classpath cuando la aplicación se ejecuta en el entorno de producción.