### PR TITLE
Fix(db): Habilitar creación automática del esquema de BD

### DIFF
--- a/app-web/src/main/resources/application-production.properties
+++ b/app-web/src/main/resources/application-production.properties
@@ -17,10 +17,11 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 # ===============================================================
 # = HIBERNATE/JPA CONFIGURATION
 # ===============================================================
-# 'validate' ensures the database schema matches the entities on startup,
-# which is a safe policy for production. It prevents Hibernate from
-# making unexpected changes to the schema.
-spring.jpa.hibernate.ddl-auto=validate
+# 'update' will create the database schema on first startup if it's
+# missing, and attempt to update it on subsequent startups if the
+# entities have changed. This is suitable for development and initial
+# deployments.
+spring.jpa.hibernate.ddl-auto=update
 
 # Disable verbose SQL logging in production.
 spring.jpa.show-sql=false


### PR DESCRIPTION
El despliegue fallaba en el arranque con un error de validación de esquema (`Schema-validation: missing table`) porque la base de datos era nueva y no tenía tablas.

Para solucionar esto, modifiqué la propiedad `spring.jpa.hibernate.ddl-auto` de `validate` a `update` en el perfil de producción.

Este nuevo valor permite que Hibernate cree automáticamente el esquema de la base de datos la primera vez que la aplicación se conecta a una base de datos vacía, y que lo actualice en futuros despliegues. Esto soluciona el error de arranque y permite que la inicialización de la aplicación continúe.