### PR TITLE
Fix(email): Use correct method to get username

### DIFF
--- a/app-web/src/main/java/com/tdtsqlscan/web/event/RegistrationListener.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/event/RegistrationListener.java
@@ -55,7 +55,7 @@ public class RegistrationListener implements ApplicationListener<OnRegistrationC
     private MimeMessage constructMimeMessage(final OnRegistrationCompleteEvent event, final User user, final String token) throws MessagingException {
         // Prepare the evaluation context
         final Context ctx = new Context();
-        ctx.setVariable("userName", user.getFirstName());
+        ctx.setVariable("userName", user.getUsername());
         ctx.setVariable("appName", this.appName);
         final String confirmationUrl = event.getAppUrl() + "/verify?token=" + token;
         ctx.setVariable("confirmationUrl", confirmationUrl);


### PR DESCRIPTION
This commit fixes a compilation error in `RegistrationListener`.

The previous commit incorrectly assumed the `User` object had a `getFirstName()` method. This commit corrects the method call to `getUsername()`, which is the correct method for retrieving the user's name from the `User` entity.