### PR TITLE
Fix(config): Use environment variables for mail config

### DIFF
--- a/app-web/src/main/resources/application-production.properties
+++ b/app-web/src/main/resources/application-production.properties
@@ -39,3 +39,12 @@ spring.h2.console.enabled=false
 # excessive logging.
 logging.level.root=INFO
 logging.level.com.tdtsqlscan=INFO
+
+# ===============================================================
+# = PRODUCTION MAIL SERVER CONFIGURATION
+# ===============================================================
+# These properties are overridden by environment variables in production.
+spring.mail.host=${SPRING_MAIL_HOST}
+spring.mail.port=${SPRING_MAIL_PORT}
+spring.mail.username=${SPRING_MAIL_USERNAME}
+spring.mail.password=${SPRING_MAIL_PASSWORD}


### PR DESCRIPTION
The email sending was failing in the production environment because the mail server properties were not configured for the production profile. The application was falling back to the default placeholder values (e.g., smtp.example.com).

This commit adds the `spring.mail.*` properties to `application-production.properties` and configures them to read their values from environment variables (`SPRING_MAIL_HOST`, `SPRING_MAIL_PORT`, etc.).

This allows the mail service to be correctly configured in a production environment like Render without hardcoding credentials in the source code.