### PR TITLE
Feat(auth): Resend verification email on re-registration

### DIFF
--- a/app-web/src/main/java/com/tdtsqlscan/web/controller/RegistrationController.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/controller/RegistrationController.java
@@ -33,10 +33,17 @@ public class RegistrationController {
     @PostMapping("/register")
     public String registerUserAccount(@ModelAttribute("user") UserDto userDto, WebRequest request, Model model) {
         try {
-            User registered = userService.registerNewUserAccount(userDto);
+            RegistrationResult result = userService.registerNewUserAccount(userDto);
+            User registered = result.getUser();
+
             final String appUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
             eventPublisher.publishEvent(new OnRegistrationCompleteEvent(registered, appUrl));
-            model.addAttribute("message", "A verification email has been sent to " + userDto.getEmail());
+
+            if (result.isResent()) {
+                model.addAttribute("message", "This email is already registered but not yet verified. A new verification email has been sent to " + userDto.getEmail() + ". Please check your inbox. Your original registration data will be used.");
+            } else {
+                model.addAttribute("message", "A verification email has been sent to " + userDto.getEmail() + ". Please check your inbox to activate your account.");
+            }
         } catch (Exception ex) {
             model.addAttribute("error", ex.getMessage());
             return "register";

--- a/app-web/src/main/java/com/tdtsqlscan/web/dto/RegistrationResult.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/dto/RegistrationResult.java
@@ -1,0 +1,22 @@
+package com.tdtsqlscan.web.dto;
+
+import com.tdtsqlscan.web.domain.User;
+
+public class RegistrationResult {
+
+    private final User user;
+    private final boolean resent;
+
+    public RegistrationResult(User user, boolean resent) {
+        this.user = user;
+        this.resent = resent;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public boolean isResent() {
+        return resent;
+    }
+}

--- a/app-web/src/main/java/com/tdtsqlscan/web/repository/VerificationTokenRepository.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/repository/VerificationTokenRepository.java
@@ -1,5 +1,6 @@
 package com.tdtsqlscan.web.repository;
 
+import com.tdtsqlscan.web.domain.User;
 import com.tdtsqlscan.web.domain.VerificationToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
@@ -7,5 +8,9 @@ import java.util.Optional;
 public interface VerificationTokenRepository extends JpaRepository<VerificationToken, Long> {
 
     Optional<VerificationToken> findByToken(String token);
+
+    Optional<VerificationToken> findByUser(User user);
+
+    void deleteByUser(User user);
 
 }

--- a/app-web/src/main/java/com/tdtsqlscan/web/service/UserService.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/service/UserService.java
@@ -33,24 +33,39 @@ public class UserService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    public User registerNewUserAccount(UserDto userDto) throws Exception {
+    public RegistrationResult registerNewUserAccount(UserDto userDto) throws Exception {
         if (userRepository.findByUsername(userDto.getUsername()).isPresent()) {
             throw new Exception("There is an account with that username: " + userDto.getUsername());
         }
-        if (userRepository.findByEmail(userDto.getEmail()).isPresent()) {
-            throw new Exception("There is an account with that email address: " + userDto.getEmail());
+
+        // Check if email exists
+        final Optional<User> userOptional = userRepository.findByEmail(userDto.getEmail());
+        if (userOptional.isPresent()) {
+            User existingUser = userOptional.get();
+            if (existingUser.isEnabled()) {
+                // User exists and is verified, throw error
+                throw new Exception("There is an account with that email address: " + userDto.getEmail());
+            } else {
+                // User exists but is not verified, signal to resend email
+                return new RegistrationResult(existingUser, true);
+            }
         }
 
+        // Create a new user if no account with that email exists
         User user = new User();
         user.setUsername(userDto.getUsername());
         user.setEmail(userDto.getEmail());
         user.setPassword(passwordEncoder.encode(userDto.getPassword()));
         user.setRoles("USER");
         user.setEnabled(false);
-        return userRepository.save(user);
+        User savedUser = userRepository.save(user);
+        return new RegistrationResult(savedUser, false);
     }
 
     public void createVerificationTokenForUser(final User user, final String token) {
+        // A user should only have one active verification token. Delete any existing ones.
+        tokenRepository.findByUser(user).ifPresent(tokenRepository::delete);
+
         final VerificationToken myToken = new VerificationToken(user);
         myToken.setToken(token);
         tokenRepository.save(myToken);


### PR DESCRIPTION
This commit implements a new feature to improve the user registration experience.

If a user tries to register with an email that already exists but has not yet been verified, the system will now:
- Not create a new user or update existing data.
- Generate a new verification token for the existing user.
- Resend the verification email.
- Inform the user that a new email has been sent.

This prevents users from getting stuck if they lose their initial verification email.

Changes include:
- A new `RegistrationResult` DTO to communicate the outcome from the service.
- Updated logic in `UserService` to handle this specific registration scenario.
- Updated `RegistrationController` to display the correct message to the user.
- Enhanced `VerificationTokenRepository` to manage tokens more robustly.