### PR TITLE
Fix(auth): Correct registration validation and email 'From' header

### DIFF
--- a/app-web/src/main/java/com/tdtsqlscan/web/service/UserService.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/service/UserService.java
@@ -36,24 +36,26 @@ public class UserService {
     private PasswordEncoder passwordEncoder;
 
     public RegistrationResult registerNewUserAccount(UserDto userDto) throws Exception {
-        if (userRepository.findByUsername(userDto.getUsername()).isPresent()) {
-            throw new Exception("There is an account with that username: " + userDto.getUsername());
-        }
-
-        // Check if email exists
-        final Optional<User> userOptional = userRepository.findByEmail(userDto.getEmail());
-        if (userOptional.isPresent()) {
-            User existingUser = userOptional.get();
+        // Priority 1: Check if email exists
+        final Optional<User> userByEmail = userRepository.findByEmail(userDto.getEmail());
+        if (userByEmail.isPresent()) {
+            User existingUser = userByEmail.get();
             if (existingUser.isEnabled()) {
-                // User exists and is verified, throw error
+                // User exists and is verified, throw error.
                 throw new Exception("There is an account with that email address: " + userDto.getEmail());
             } else {
-                // User exists but is not verified, signal to resend email
+                // User exists but is not verified. Resend verification email.
+                // Ignore all other data from the new registration attempt.
                 return new RegistrationResult(existingUser, true);
             }
         }
 
-        // Create a new user if no account with that email exists
+        // Priority 2: Check if username is taken, only if email is new
+        if (userRepository.findByUsername(userDto.getUsername()).isPresent()) {
+            throw new Exception("There is an account with that username: " + userDto.getUsername());
+        }
+
+        // If both email and username are new, create the new user.
         User user = new User();
         user.setUsername(userDto.getUsername());
         user.setEmail(userDto.getEmail());

--- a/app-web/src/main/resources/application-production.properties
+++ b/app-web/src/main/resources/application-production.properties
@@ -44,6 +44,7 @@ logging.level.com.tdtsqlscan=INFO
 # = PRODUCTION MAIL SERVER CONFIGURATION
 # ===============================================================
 # These properties are overridden by environment variables in production.
+spring.mail.from=${SPRING_MAIL_FROM}
 spring.mail.host=${SPRING_MAIL_HOST}
 spring.mail.port=${SPRING_MAIL_PORT}
 spring.mail.username=${SPRING_MAIL_USERNAME}

--- a/app-web/src/main/resources/application.properties
+++ b/app-web/src/main/resources/application.properties
@@ -25,6 +25,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
 # Mail Server Configuration (placeholders - PLEASE CONFIGURE)
+spring.mail.from=noreply@example.com
 spring.mail.host=smtp.example.com
 spring.mail.port=587
 spring.mail.username=your-email@example.com


### PR DESCRIPTION
This commit addresses two issues in the user registration flow.

1.  **Incorrect Validation Order:** The registration logic was checking for username existence before email existence. This has been corrected to check for the email first, allowing the email resend feature to trigger correctly even if the username is the same.
2.  **Missing 'From' Header:** The email sending was failing with a `550 Missing 'From' header` error. This was because the `spring.mail.from` property was not set. This commit adds the `spring.mail.from` property to the configuration, making it configurable via the `SPRING_MAIL_FROM` environment variable in production.