### PR TITLE
Fix(email): Explicitly set 'From' header to prevent send failure

### DIFF
--- a/app-web/src/main/java/com/tdtsqlscan/web/event/RegistrationListener.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/event/RegistrationListener.java
@@ -33,6 +33,9 @@ public class RegistrationListener implements ApplicationListener<OnRegistrationC
     @Value("${app.email.registration.subject}")
     private String registrationSubject;
 
+    @Value("${spring.mail.from}")
+    private String fromAddress;
+
     @Override
     public void onApplicationEvent(final OnRegistrationCompleteEvent event) {
         try {
@@ -66,6 +69,7 @@ public class RegistrationListener implements ApplicationListener<OnRegistrationC
         // Prepare message using a Spring MimeMessageHelper
         final MimeMessage mimeMessage = this.mailSender.createMimeMessage();
         final MimeMessageHelper message = new MimeMessageHelper(mimeMessage, "UTF-8");
+        message.setFrom(this.fromAddress);
         message.setSubject(this.registrationSubject);
         message.setTo(user.getEmail());
         message.setText(htmlContent, true); // true = is HTML


### PR DESCRIPTION
This commit provides a more robust fix for the `SMTPSendFailedException: 550 MIME message is missing 'From' header` error.

The previous configuration-only approach was not sufficient. This change ensures the 'From' address is always set programmatically by:
1.  Injecting the `spring.mail.from` property into the `RegistrationListener`.
2.  Explicitly calling `message.setFrom()` on the `MimeMessageHelper` before sending the email.

This guarantees the `From` header will be present and should resolve the issue definitively.