### PR TITLE
Feat(admin): Allow deletion of user suggestions

### DIFF
--- a/app-web/src/main/java/com/tdtsqlscan/web/controller/AdminController.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/controller/AdminController.java
@@ -9,8 +9,10 @@ import com.tdtsqlscan.web.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/admin")
@@ -54,5 +56,12 @@ public class AdminController {
     public String showSuggestions(Model model) {
         model.addAttribute("suggestions", suggestionRepository.findAll());
         return "admin/suggestions";
+    }
+
+    @PostMapping("/suggestions/delete/{id}")
+    public String deleteSuggestion(@PathVariable("id") Long id, RedirectAttributes redirectAttributes) {
+        suggestionRepository.deleteById(id);
+        redirectAttributes.addFlashAttribute("message", "Suggestion deleted successfully.");
+        return "redirect:/admin/suggestions";
     }
 }

--- a/app-web/src/main/resources/templates/admin/suggestions.html
+++ b/app-web/src/main/resources/templates/admin/suggestions.html
@@ -13,8 +13,10 @@
         .main-content { flex-grow: 1; padding: 40px; }
         .main-content h1 { border-bottom: 2px solid #dee2e6; padding-bottom: 10px; }
         .suggestion-card { background-color: #fff; border: 1px solid #dee2e6; border-radius: 5px; padding: 20px; margin-bottom: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
-        .suggestion-meta { font-size: 0.9rem; color: #6c757d; margin-bottom: 10px; border-bottom: 1px solid #eee; padding-bottom: 10px; }
+        .suggestion-meta { font-size: 0.9rem; color: #6c757d; margin-bottom: 10px; border-bottom: 1px solid #eee; padding-bottom: 10px; display: flex; justify-content: space-between; align-items: center; }
         .suggestion-text { white-space: pre-wrap; }
+        .delete-btn { background-color: #dc3545; color: white; border: none; padding: 5px 10px; border-radius: 3px; cursor: pointer; font-size: 0.8rem; }
+        .delete-btn:hover { background-color: #c82333; }
     </style>
 </head>
 <body>
@@ -38,8 +40,13 @@
 
             <div class="suggestion-card" th:each="suggestion : ${suggestions}">
                 <div class="suggestion-meta">
-                    <strong>User:</strong> <span th:text="${suggestion.user.username}"></span> |
-                    <strong>Date:</strong> <span th:text="${#dates.format(suggestion.submissionDate, 'yyyy-MM-dd HH:mm')}"></span>
+                    <div>
+                        <strong>User:</strong> <span th:text="${suggestion.user.username}"></span> |
+                        <strong>Date:</strong> <span th:text="${#dates.format(suggestion.submissionDate, 'yyyy-MM-dd HH:mm')}"></span>
+                    </div>
+                    <form th:action="@{/admin/suggestions/delete/{id}(id=${suggestion.id})}" method="post" onsubmit="return confirm('Are you sure you want to delete this suggestion?');">
+                        <button type="submit" class="delete-btn">Delete</button>
+                    </form>
                 </div>
                 <p class="suggestion-text" th:text="${suggestion.text}"></p>
             </div>


### PR DESCRIPTION
This commit implements a feature allowing administrators to delete user suggestions from the admin panel.

Changes include:
- A 'Delete' button has been added to each suggestion card in the admin view.
- A confirmation dialog is shown to prevent accidental deletion.
- A new endpoint `POST /admin/suggestions/delete/{id}` has been added to `AdminController` to handle the deletion logic.
- The controller calls `SuggestionRepository.deleteById()` to remove the entity from the database.