### PR TITLE
feat: Implement blog feature and apply homepage corrections

### DIFF
--- a/app-cli/dependency-reduced-pom.xml
+++ b/app-cli/dependency-reduced-pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>tdt-sql-scan</artifactId>
+    <groupId>com.tdtsqlscan</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>app-cli</artifactId>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer>
+                  <mainClass>com.tdtsqlscan.appcli.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/app-web/src/main/java/com/tdtsqlscan/web/controller/AdminPostController.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/controller/AdminPostController.java
@@ -3,6 +3,7 @@ package com.tdtsqlscan.web.controller;
 import com.tdtsqlscan.web.domain.Post;
 import com.tdtsqlscan.web.service.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
@@ -22,6 +23,9 @@ public class AdminPostController {
 
     private final PostService postService;
 
+    @Value("${tinymce.api.key}")
+    private String tinymceApiKey;
+
     @Autowired
     public AdminPostController(PostService postService) {
         this.postService = postService;
@@ -36,6 +40,7 @@ public class AdminPostController {
     @GetMapping("/new")
     public String showCreateForm(Model model) {
         model.addAttribute("post", new Post());
+        model.addAttribute("tinymceApiKey", tinymceApiKey);
         return "admin/posts/form"; // Thymeleaf template path
     }
 
@@ -54,6 +59,7 @@ public class AdminPostController {
         return postService.findById(id)
                 .map(post -> {
                     model.addAttribute("post", post);
+                    model.addAttribute("tinymceApiKey", tinymceApiKey);
                     return "admin/posts/form"; // Thymeleaf template path
                 })
                 .orElseGet(() -> {

--- a/app-web/src/main/resources/application.properties
+++ b/app-web/src/main/resources/application.properties
@@ -33,3 +33,6 @@ spring.mail.username=your-email@example.com
 spring.mail.password=your-password
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+# TinyMCE Configuration
+tinymce.api.key=${TINYMCE_API_KEY:no-api-key}

--- a/app-web/src/main/resources/templates/admin/posts/form.html
+++ b/app-web/src/main/resources/templates/admin/posts/form.html
@@ -20,7 +20,7 @@
         .btn-secondary { background-color: #6c757d; }
     </style>
     <!-- TinyMCE Script -->
-    <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+    <script th:src="@{'https://cdn.tiny.cloud/1/' + ${tinymceApiKey} + '/tinymce/6/tinymce.min.js'}" referrerpolicy="origin"></script>
     <script>
         tinymce.init({
             selector: 'textarea#content-editor',


### PR DESCRIPTION
In this commit, I've introduced a comprehensive blog system and applied several updates to the homepage, per your instructions.

The blog functionality allows administrators to create, edit, and delete posts through a new "Blog Management" section in the admin panel, which features a rich text editor. Public users can view these posts on a new, public-facing blog section. The TinyMCE API key is now loaded from the `TINYMCE_API_KEY` environment variable.

Additionally, I've made the following corrections to the homepage:
- The application name is updated to "Data Flow Visualizer".
- The copyright year is updated to 2025.
- SEO-related tags (`title`, `meta`, `h1`) have been added and updated.