### PR TITLE
fix(admin): Add missing navigation links to blog management pages

### DIFF
--- a/app-web/src/main/resources/templates/admin/posts/form.html
+++ b/app-web/src/main/resources/templates/admin/posts/form.html
@@ -51,6 +51,8 @@
             <li><a th:href="@{/admin/users}">User Management</a></li>
             <li><a th:href="@{/admin/suggestions}">View Suggestions</a></li>
             <li><a th:href="@{/admin/posts}" class="active">Blog Management</a></li>
+                <li><a th:href="@{/admin/faqs}">FAQ Management</a></li>
+                <li><a th:href="@{/admin/whats-new}">What's New Management</a></li>
             <li><a th:href="@{/app}">Back to App</a></li>
         </ul>
     </nav>

--- a/app-web/src/main/resources/templates/admin/posts/list.html
+++ b/app-web/src/main/resources/templates/admin/posts/list.html
@@ -21,6 +21,8 @@
             <li><a th:href="@{/admin/users}">User Management</a></li>
             <li><a th:href="@{/admin/suggestions}">View Suggestions</a></li>
             <li><a th:href="@{/admin/posts}" class="active">Blog Management</a></li>
+                <li><a th:href="@{/admin/faqs}">FAQ Management</a></li>
+                <li><a th:href="@{/admin/whats-new}">What's New Management</a></li>
             <li><a th:href="@{/app}">Back to App</a></li>
         </ul>
     </nav>


### PR DESCRIPTION
This commit fixes a UI bug in the admin panel where the navigation links to the 'FAQ' and 'What's New' management sections were missing from the sidebar on the 'Blog Management' pages (`list` and `form`).

This change adds the missing links to `admin/posts/list.html` and `admin/posts/form.html` to ensure a consistent navigation experience across all admin panel sections.