### PR TITLE
Fix parsing of table names with trailing parenthesis

### DIFF
--- a/app-web/src/main/java/com/tdtsqlscan/web/BteqUploadController.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/BteqUploadController.java
@@ -11,6 +11,7 @@ import com.tdtsqlscan.etl.BteqScript;
 import com.tdtsqlscan.etl.BteqScriptParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tdtsqlscan.core.SQLParserUtils;
 import com.tdtsqlscan.core.SQLQuery;
 import com.tdtsqlscan.core.SQLTableRef;
 import com.tdtsqlscan.ddl.CreateTableQuery;
@@ -133,7 +134,7 @@ public class BteqUploadController {
                         if (query instanceof SelectQuery) {
                             SelectQuery selectQuery = (SelectQuery) query;
                             for (SQLTableRef tableRef : selectQuery.getTables()) {
-                                readTables.add(tableRef.getExpression().split(" ")[0].toUpperCase());
+                                readTables.add(SQLParserUtils.extractTableFromExpression(tableRef.getExpression()).toUpperCase());
                             }
                         } else if (query instanceof InsertQuery) {
                             InsertQuery insertQuery = (InsertQuery) query;

--- a/parser-core/src/main/java/com/tdtsqlscan/core/SQLParserUtils.java
+++ b/parser-core/src/main/java/com/tdtsqlscan/core/SQLParserUtils.java
@@ -59,9 +59,31 @@ public class SQLParserUtils {
     public static String getFirstWord(String s) {
         String[] words = s.trim().split("\\s+");
         if (words.length > 0) {
-            return words[0];
+            String word = words[0];
+            // Clean trailing characters that are not part of the name
+            while (word.length() > 0 && (word.endsWith(")") || word.endsWith(",") || word.endsWith(";"))) {
+                word = word.substring(0, word.length() - 1);
+            }
+            return word;
         }
         return "";
+    }
+
+    public static String extractTableFromExpression(String expression) {
+        String table = expression.trim();
+
+        // Split by space to separate table name from alias
+        String[] parts = table.split("\\s+");
+        if (parts.length == 0) {
+            return "";
+        }
+        String baseName = parts[0];
+
+        // Clean trailing characters that are not part of the name
+        while (baseName.length() > 0 && (baseName.endsWith(")") || baseName.endsWith(",") || baseName.endsWith(";"))) {
+            baseName = baseName.substring(0, baseName.length() - 1);
+        }
+        return baseName;
     }
 
     public static String extractTableName(String sql, String keyword) {

--- a/parser-dml/pom.xml
+++ b/parser-dml/pom.xml
@@ -18,6 +18,11 @@
       <artifactId>parser-core</artifactId>
       <version>0.4.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.tdtsqlscan</groupId>
+      <artifactId>parser-select</artifactId>
+      <version>0.4.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parser-dml/src/main/java/com/tdtsqlscan/dml/UpdateParser.java
+++ b/parser-dml/src/main/java/com/tdtsqlscan/dml/UpdateParser.java
@@ -1,16 +1,17 @@
 package com.tdtsqlscan.dml;
 
 import com.tdtsqlscan.core.QueryParser;
-import com.tdtsqlscan.core.SQLAssignment;
-import com.tdtsqlscan.core.SQLCondition;
 import com.tdtsqlscan.core.SQLParseException;
 import com.tdtsqlscan.core.SQLParserUtils;
 import com.tdtsqlscan.core.SQLQuery;
-
-import java.util.List;
+import com.tdtsqlscan.core.SQLTableRef;
+import com.tdtsqlscan.select.SelectParser;
+import com.tdtsqlscan.select.SelectQuery;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class UpdateParser implements QueryParser {
 
@@ -22,20 +23,37 @@ public class UpdateParser implements QueryParser {
     @Override
     public SQLQuery parse(String sql) throws SQLParseException {
         String upperSql = sql.toUpperCase();
-        // Use extractBetweenKeywords for more robustness, as the table is between UPDATE and SET.
         String targetTable = SQLParserUtils.extractBetweenKeywords(upperSql, "UPDATE", "SET");
         if (targetTable != null) {
-            // The result might include an alias, get the first word.
             targetTable = SQLParserUtils.getFirstWord(targetTable);
         }
 
-        List<String> sourceTables = null;
+        List<String> sourceTables = new ArrayList<>();
+
+        // Extract tables from FROM clause if it exists
         if (upperSql.contains(" FROM ")) {
             String fromClause = SQLParserUtils.extractAfterKeyword(upperSql, "FROM", "WHERE");
             if (fromClause != null && !fromClause.isEmpty()) {
                 // This is a simplistic implementation. A real one would need to handle joins, aliases etc.
                 String sourceTable = SQLParserUtils.getFirstWord(fromClause.trim());
-                sourceTables = Collections.singletonList(sourceTable);
+                sourceTables.add(sourceTable);
+            }
+        }
+
+        // Extract tables from subqueries in SET clause
+        String setClause = SQLParserUtils.extractBetweenKeywords(sql, "SET", "WHERE");
+        if (setClause == null) {
+            setClause = SQLParserUtils.extractAfterKeyword(sql, "SET", null);
+        }
+
+        if (setClause != null) {
+            // Use regex to find all subqueries in the SET clause.
+            // This regex looks for patterns like (SELECT ... FROM table ...)
+            // It captures the table name, which might be followed by an alias.
+            Pattern pattern = Pattern.compile("FROM\\s+([\\w\\.]+)", Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(setClause);
+            while (matcher.find()) {
+                sourceTables.add(SQLParserUtils.getFirstWord(matcher.group(1)));
             }
         }
 


### PR DESCRIPTION
- Updated SQLParserUtils to correctly extract table names that might be followed by a closing parenthesis.
- Updated UpdateParser to correctly identify source tables from subqueries in the SET clause.
- Updated BteqUploadController to use the new parsing logic.