### PR TITLE
feat: Apply professional redesign to static pages

### DIFF
--- a/app-web/src/main/resources/templates/blog/list.html
+++ b/app-web/src/main/resources/templates/blog/list.html
@@ -1,14 +1,9 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" class="dark">
 <head>
     <title>Blog | Data Flow Visualizer</title>
     <meta name="description" content="Articles and updates on data engineering, Business Intelligence, Teradata, and the evolution of the Data Flow Visualizer tool." />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <script>
-        tailwind.config = {
-            darkMode: 'class',
-        }
-    </script>
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <link
@@ -18,32 +13,31 @@
       href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
     />
 </head>
-<body class="bg-white dark:bg-gray-900" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<body style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
+        <canvas class="background"></canvas>
         <div class="layout-container flex h-full grow flex-col">
             <div th:replace="~{fragments/header :: header}"></div>
 
-            <main class="flex-1 justify-center py-5 px-4 sm:px-6 lg:px-8">
+            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
                 <div class="max-w-4xl mx-auto">
-                    <h1 class="text-4xl font-bold text-center text-gray-800 dark:text-white mb-10">Our Blog</h1>
+                    <h1 class="text-4xl font-bold text-center text-white mb-12">Our Blog</h1>
 
                     <div class="space-y-12">
-                        <div th:each="post : ${posts}" class="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow duration-300">
-                            <div class="p-6">
-                                <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-2">
-                                    <a th:href="@{/blog/{slug}(slug=${post.slug})}" th:text="${post.title}" class="hover:text-[#21bded] transition-colors duration-300">Post Title</a>
-                                </h2>
-                                <div class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                                    <span>By <span th:text="${post.author}">Author</span></span> |
-                                    <span>Published on <span th:text="${#temporals.format(post.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
-                                </div>
-                                <!-- Summary is not available in the Post entity -->
-                                <a th:href="@{/blog/{slug}(slug=${post.slug})}" class="text-[#21bded] font-semibold hover:underline">Read more &rarr;</a>
+                        <div th:each="post : ${posts}" class="feature-card">
+                            <h2 class="text-2xl font-bold text-white mb-2">
+                                <a th:href="@{/blog/{slug}(slug=${post.slug})}" th:text="${post.title}" class="hover:text-blue-400 transition-colors duration-300">Post Title</a>
+                            </h2>
+                            <div class="text-sm text-gray-400 mb-4">
+                                <span>By <span th:text="${post.author}">Author</span></span> |
+                                <span>Published on <span th:text="${#temporals.format(post.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
                             </div>
+                            <!-- Summary is not available in the Post entity -->
+                            <a th:href="@{/blog/{slug}(slug=${post.slug})}" class="font-semibold text-blue-400 hover:underline">Read more &rarr;</a>
                         </div>
 
                         <div th:if="${posts.isEmpty()}" class="text-center py-10">
-                            <p class="text-gray-500 dark:text-gray-400">No blog posts have been published yet. Check back soon!</p>
+                            <p class="text-gray-400">No blog posts have been published yet. Check back soon!</p>
                         </div>
                     </div>
                 </div>
@@ -52,6 +46,7 @@
             <div th:replace="~{fragments/footer :: footer}"></div>
         </div>
     </div>
-    <script th:src="@{/js/theme.js}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
+    <script th:src="@{/js/particles-config.js}"></script>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/blog/post.html
+++ b/app-web/src/main/resources/templates/blog/post.html
@@ -1,14 +1,9 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" class="dark">
 <head>
     <title th:text="${post.title} + ' | Data Flow Visualizer Blog'"></title>
     <meta name="description" th:attr="content=${#strings.abbreviate(post.content, 155)}" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <script>
-        tailwind.config = {
-            darkMode: 'class',
-        }
-    </script>
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <link
@@ -18,27 +13,28 @@
       href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
     />
 </head>
-<body class="bg-white dark:bg-gray-900" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<body style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
+        <canvas class="background"></canvas>
         <div class="layout-container flex h-full grow flex-col">
             <div th:replace="~{fragments/header :: header}"></div>
 
-            <main class="flex-1 justify-center py-5 px-4 sm:px-6 lg:px-8">
+            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
                 <div class="max-w-4xl mx-auto">
-                    <article class="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden p-6">
-                        <header class="border-b dark:border-gray-700 pb-4 mb-4">
-                            <h1 class="text-4xl font-bold text-gray-800 dark:text-gray-100" th:text="${post.title}">Post Title</h1>
-                            <div class="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                    <article class="feature-card">
+                        <header class="border-b border-white/20 pb-4 mb-4">
+                            <h1 class="text-4xl font-bold text-white" th:text="${post.title}">Post Title</h1>
+                            <div class="text-sm text-gray-400 mt-2">
                                 <span>By <span th:text="${post.author}">Author</span></span> |
                                 <span>Published on <span th:text="${#temporals.format(post.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
                             </div>
                         </header>
-                        <section class="prose max-w-none dark:prose-invert" th:utext="${post.content}">
+                        <section class="prose prose-invert max-w-none" th:utext="${post.content}">
                             <!-- Post content will be rendered here -->
                         </section>
                     </article>
                     <div class="mt-8 text-center">
-                        <a th:href="@{/blog}" class="text-[#21bded] font-semibold hover:underline">&larr; Back to Blog</a>
+                        <a th:href="@{/blog}" class="font-semibold text-blue-400 hover:underline">&larr; Back to Blog</a>
                     </div>
                 </div>
             </main>
@@ -46,6 +42,7 @@
             <div th:replace="~{fragments/footer :: footer}"></div>
         </div>
     </div>
-    <script th:src="@{/js/theme.js}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
+    <script th:src="@{/js/particles-config.js}"></script>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/faq.html
+++ b/app-web/src/main/resources/templates/faq.html
@@ -1,15 +1,10 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" class="dark">
 <head>
     <title>FAQ | Data Flow Visualizer</title>
     <meta name="description" content="Frequently Asked Questions about the Data Flow Visualizer tool." />
     <meta name="keywords" content="FAQ, Data Flow Visualizer, Teradata, BTEQ, SQL, ETL, Data Lineage, Support, Help" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <script>
-        tailwind.config = {
-            darkMode: 'class',
-        }
-    </script>
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <link
@@ -20,48 +15,53 @@
     />
     <style>
         .faq-item {
-            border: 1px solid #e2e8f0;
-            border-radius: 0.5rem;
+            background: rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 16px;
             margin-bottom: 1rem;
             overflow: hidden;
         }
         .faq-question {
             width: 100%;
             text-align: left;
-            padding: 1rem 1.5rem;
+            padding: 1.5rem;
             font-weight: 600;
             cursor: pointer;
             display: flex;
             justify-content: space-between;
             align-items: center;
+            color: white;
         }
         .faq-answer {
-            padding: 1rem 1.5rem;
+            padding: 0 1.5rem 1.5rem 1.5rem;
             display: none;
+            color: #e2e8f0;
         }
     </style>
 </head>
-<body class="bg-white dark:bg-gray-900" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<body style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
+        <canvas class="background"></canvas>
         <div class="layout-container flex h-full grow flex-col">
             <div th:replace="~{fragments/header :: header}"></div>
 
-            <main class="flex-1 justify-center py-5 px-4 sm:px-6 lg:px-8">
+            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
                 <div class="max-w-4xl mx-auto">
-                    <h1 class="text-4xl font-bold text-center text-gray-800 dark:text-white mb-10">Frequently Asked Questions</h1>
+                    <h1 class="text-4xl font-bold text-center text-white mb-12">Frequently Asked Questions</h1>
 
                     <div class="space-y-4">
-                        <div th:each="faq : ${faqs}" class="faq-item bg-white dark:bg-gray-800 rounded-lg shadow-md">
-                            <button class="faq-question text-gray-800 dark:text-gray-100">
+                        <div th:each="faq : ${faqs}" class="faq-item">
+                            <button class="faq-question">
                                 <span th:text="${faq.question}"></span>
                                 <span>&#9660;</span>
                             </button>
-                            <div class="faq-answer text-gray-600 dark:text-gray-300" th:utext="${faq.answer}">
+                            <div class="faq-answer prose prose-invert max-w-none" th:utext="${faq.answer}">
                             </div>
                         </div>
 
                         <div th:if="${faqs.isEmpty()}" class="text-center py-10">
-                            <p class="text-gray-500 dark:text-gray-400">No FAQs have been published yet. Check back soon!</p>
+                            <p class="text-gray-400">No FAQs have been published yet. Check back soon!</p>
                         </div>
                     </div>
                 </div>
@@ -70,7 +70,8 @@
             <div th:replace="~{fragments/footer :: footer}"></div>
         </div>
     </div>
-    <script th:src="@{/js/theme.js}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
+    <script th:src="@{/js/particles-config.js}"></script>
     <script>
         document.querySelectorAll('.faq-question').forEach(button => {
             button.addEventListener('click', () => {

--- a/app-web/src/main/resources/templates/whats-new.html
+++ b/app-web/src/main/resources/templates/whats-new.html
@@ -1,15 +1,10 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" class="dark">
 <head>
     <title>What's New | Data Flow Visualizer</title>
     <meta name="description" content="Latest updates and new features of the Data Flow Visualizer tool." />
     <meta name="keywords" content="What's New, Updates, Features, Data Flow Visualizer, Teradata, BTEQ, SQL, ETL, Data Lineage" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <script>
-        tailwind.config = {
-            darkMode: 'class',
-        }
-    </script>
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <link
@@ -19,28 +14,27 @@
       href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
     />
 </head>
-<body class="bg-white dark:bg-gray-900" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<body style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
+        <canvas class="background"></canvas>
         <div class="layout-container flex h-full grow flex-col">
             <div th:replace="~{fragments/header :: header}"></div>
 
-            <main class="flex-1 justify-center py-5 px-4 sm:px-6 lg:px-8">
+            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
                 <div class="max-w-4xl mx-auto">
-                    <h1 class="text-4xl font-bold text-center text-gray-800 dark:text-white mb-10">What's New</h1>
+                    <h1 class="text-4xl font-bold text-center text-white mb-12">What's New</h1>
 
                     <div class="space-y-12">
-                        <div th:each="item : ${whatsnews}" class="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden">
-                            <div class="p-6">
-                                <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-2" th:text="${item.title}"></h2>
-                                <div class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                                    <span>Published on <span th:text="${#temporals.format(item.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
-                                </div>
-                                <div class="prose dark:prose-invert max-w-none" th:utext="${item.content}"></div>
+                        <div th:each="item : ${whatsnews}" class="feature-card">
+                            <h2 class="text-2xl font-bold text-white mb-2" th:text="${item.title}"></h2>
+                            <div class="text-sm text-gray-400 mb-4">
+                                <span>Published on <span th:text="${#temporals.format(item.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
                             </div>
+                            <div class="prose prose-invert max-w-none" th:utext="${item.content}"></div>
                         </div>
 
                         <div th:if="${whatsnews.isEmpty()}" class="text-center py-10">
-                            <p class="text-gray-500 dark:text-gray-400">No updates have been published yet. Check back soon!</p>
+                            <p class="text-gray-400">No updates have been published yet. Check back soon!</p>
                         </div>
                     </div>
                 </div>
@@ -49,6 +43,7 @@
             <div th:replace="~{fragments/footer :: footer}"></div>
         </div>
     </div>
-    <script th:src="@{/js/theme.js}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
+    <script th:src="@{/js/particles-config.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit applies the new professional design to the FAQ, What's New, and Blog pages to ensure a consistent look and feel across the entire application.

The changes include:
- Redesigned `faq.html`, `whats-new.html`, `blog/list.html`, and `blog/post.html`.
- Applied the dark theme, animated background, and sticky header to all pages.
- Used a consistent card-based layout with glassmorphism effects for the content on these pages.
- Removed old, unused CSS and JavaScript related to the previous theme.

This completes the full professional redesign of the web application as requested. All pages now share a unified, modern, and professional design.