### PR TITLE
feat: Unify visual design across the application

### DIFF
--- a/app-web/src/main/resources/templates/blog/list.html
+++ b/app-web/src/main/resources/templates/blog/list.html
@@ -1,46 +1,26 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" class="dark">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title>Blog | Data Flow Visualizer</title>
-    <meta name="description" content="Articles and updates on data engineering, Business Intelligence, Teradata, and the evolution of the Data Flow Visualizer tool." />
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
-    <link
-      rel="stylesheet"
-      as="style"
-      onload="this.rel='stylesheet'"
-      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
-    />
+    <title>Blog</title>
 </head>
-<body style='font-family: Inter, "Noto Sans", sans-serif;'>
-    <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
-        <canvas class="background"></canvas>
-        <div class="layout-container flex h-full grow flex-col">
-            <div th:replace="~{fragments/header :: header}"></div>
-            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
-                <div class="max-w-4xl mx-auto">
-                    <h1 class="text-4xl font-bold text-center text-white mb-12">Our Blog</h1>
-                    <div class="space-y-12">
-                        <div th:each="post : ${posts}" class="feature-card">
-                            <h2 class="text-2xl font-bold text-white mb-2">
-                                <a th:href="@{/blog/{slug}(slug=${post.slug})}" th:text="${post.title}" class="hover:text-blue-400 transition-colors duration-300">Post Title</a>
-                            </h2>
-                            <div class="text-sm text-gray-400 mb-4">
-                                <span>By <span th:text="${post.author}">Author</span></span> |
-                                <span>Published on <span th:text="${#temporals.format(post.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
-                            </div>
-                            <a th:href="@{/blog/{slug}(slug=${post.slug})}" class="font-semibold text-blue-400 hover:underline">Read more &rarr;</a>
-                        </div>
-                        <div th:if="${posts.isEmpty()}" class="text-center py-10">
-                            <p class="text-gray-400">No blog posts have been published yet. Check back soon!</p>
-                        </div>
-                    </div>
+<body>
+<div th:fragment="content">
+    <section id="news" class="mt-24">
+        <h2 class="text-3xl font-bold text-center mb-12">Blog</h2>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div class="glassmorphism rounded-2xl overflow-hidden group news-card" th:each="post : ${posts}">
+                <div class="overflow-hidden">
+                    <img src="https://placehold.co/600x400/0a0a0a/cyan?text=News" alt="News image" class="w-full h-48 object-cover transition-transform duration-300 news-image">
                 </div>
-            </main>
-            <div th:replace="~{fragments/footer :: footer}"></div>
+                <div class="p-6">
+                    <p class="text-sm text-cyan-400 mb-2" th:text="${post.category}">Release</p>
+                    <h3 class="text-xl font-bold mb-3" th:text="${post.title}">Version 1.0 Released</h3>
+                    <p class="text-gray-400 text-sm mb-4" th:text="${post.summary}">We are excited to announce the official release of Data Flow Visualizer, ready to revolutionize your Teradata workflows!</p>
+                    <a th:href="@{'/blog/post/' + ${post.slug}}" class="font-semibold text-white hover:text-cyan-400">Read more &rarr;</a>
+                </div>
+            </div>
         </div>
-    </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
-    <script th:src="@{/js/particles-config.js}"></script>
+    </section>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/blog/post.html
+++ b/app-web/src/main/resources/templates/blog/post.html
@@ -1,43 +1,14 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" class="dark">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title th:text="${post.title} + ' | Data Flow Visualizer Blog'"></title>
-    <meta name="description" th:attr="content=${#strings.abbreviate(post.content, 155)}" />
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
-    <link
-      rel="stylesheet"
-      as="style"
-      onload="this.rel='stylesheet'"
-      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
-    />
+    <title th:text="${post.title}"></title>
 </head>
-<body style='font-family: Inter, "Noto Sans", sans-serif;'>
-    <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
-        <canvas class="background"></canvas>
-        <div class="layout-container flex h-full grow flex-col">
-            <div th:replace="~{fragments/header :: header}"></div>
-            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
-                <div class="max-w-4xl mx-auto">
-                    <article class="feature-card">
-                        <header class="border-b border-white/20 pb-4 mb-4">
-                            <h1 class="text-4xl font-bold text-white" th:text="${post.title}">Post Title</h1>
-                            <div class="text-sm text-gray-400 mt-2">
-                                <span>By <span th:text="${post.author}">Author</span></span> |
-                                <span>Published on <span th:text="${#temporals.format(post.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
-                            </div>
-                        </header>
-                        <section class="prose prose-invert max-w-none" th:utext="${post.content}"></section>
-                    </article>
-                    <div class="mt-8 text-center">
-                        <a th:href="@{/blog}" class="font-semibold text-blue-400 hover:underline">&larr; Back to Blog</a>
-                    </div>
-                </div>
-            </main>
-            <div th:replace="~{fragments/footer :: footer}"></div>
-        </div>
+<body>
+<div th:fragment="content">
+    <div class="glassmorphism rounded-3xl p-8 md:p-16">
+        <h1 class="text-4xl md:text-6xl font-black text-white leading-tight mb-4" th:text="${post.title}"></h1>
+        <div class="prose prose-invert max-w-none" th:utext="${post.content}"></div>
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
-    <script th:src="@{/js/particles-config.js}"></script>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/change-password.html
+++ b/app-web/src/main/resources/templates/change-password.html
@@ -1,32 +1,28 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title>Change Your Password</title>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
+    <title>Change Password</title>
 </head>
-<body class="bg-white dark:bg-gray-900">
-    <div th:replace="~{fragments/header :: header}"></div>
-    <div class="form-container">
-        <h2>Please Update Your Password</h2>
-        <p>For security reasons, you must change your temporary password before you can continue.</p>
-
-        <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
-
-        <form th:action="@{/change-password}" method="post">
-            <div class="form-group">
-                <label for="password">New Password:</label>
-                <input type="password" id="password" name="password" required autofocus="autofocus"/>
-            </div>
-            <div class="form-group">
-                <label for="confirmPassword">Confirm New Password:</label>
-                <input type="password" id="confirmPassword" name="confirmPassword" required />
-            </div>
-            <div>
-                <input type="submit" value="Update Password" class="btn btn-success"/>
-            </div>
-        </form>
-    </div>
-    <div th:replace="~{fragments/footer :: footer}"></div>
-    <script th:src="@{/js/theme.js}"></script>
+<body>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16">
+    <h2 class="text-2xl font-bold text-center mb-6">Change Password</h2>
+    <form th:action="@{/change-password}" method="post" class="space-y-6">
+        <div>
+            <label for="oldPassword" class="block text-sm font-medium text-gray-300">Old Password:</label>
+            <input type="password" id="oldPassword" name="oldPassword" required class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+        </div>
+        <div>
+            <label for="newPassword" class="block text-sm font-medium text-gray-300">New Password:</label>
+            <input type="password" id="newPassword" name="newPassword" required class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+        </div>
+        <div>
+            <label for="confirmPassword" class="block text-sm font-medium text-gray-300">Confirm New Password:</label>
+            <input type="password" id="confirmPassword" name="confirmPassword" required class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+        </div>
+        <div>
+            <input type="submit" value="Change Password" class="w-full px-8 py-3 font-semibold rounded-xl text-black bg-cyan-400 hover:bg-cyan-300 transition-all duration-300 transform hover:scale-105 cursor-pointer"/>
+        </div>
+    </form>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/email-verification.html
+++ b/app-web/src/main/resources/templates/email-verification.html
@@ -1,70 +1,15 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title th:text="${appName} + ' - Email Verification'"></title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Email Verification</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
-    <table border="0" cellpadding="0" cellspacing="0" width="100%">
-        <tr>
-            <td style="padding: 20px 0 30px 0;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" width="600" style="border-collapse: collapse; border: 1px solid #cccccc; background-color: #ffffff;">
-                    <!-- Header -->
-                    <tr>
-                        <td align="center" style="padding: 40px 0 30px 0; color: #2c3e50; font-size: 28px; font-weight: bold; border-bottom: 1px solid #cccccc;">
-                            <span th:text="${appName}">Data Flow Visualizer</span>
-                        </td>
-                    </tr>
-                    <!-- Body -->
-                    <tr>
-                        <td style="padding: 40px 30px 40px 30px;">
-                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                <tr>
-                                    <td style="color: #333333; font-size: 20px; font-weight: bold;">
-                                        Welcome, <span th:text="${userName}">User</span>!
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style="padding: 20px 0 30px 0; color: #555555; font-size: 16px; line-height: 1.5;">
-                                        Thank you for registering with <strong th:text="${appName}">our application</strong>. There is just one more step to activate your account.
-                                        <br/><br/>
-                                        Please click the button below to verify your email address.
-                                    </td>
-                                </tr>
-                                <!-- CTA Button -->
-                                <tr>
-                                    <td align="center">
-                                        <table border="0" cellpadding="0" cellspacing="0">
-                                            <tr>
-                                                <td align="center" style="border-radius: 5px;" bgcolor="#3498db">
-                                                    <a th:href="${confirmationUrl}" target="_blank" style="font-size: 16px; color: #ffffff; text-decoration: none; padding: 15px 25px; border-radius: 5px; display: inline-block; font-weight: bold;">
-                                                        Verify My Email
-                                                    </a>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </td>
-                                </tr>
-                                 <tr>
-                                    <td style="padding: 30px 0 0 0; color: #888888; font-size: 14px;">
-                                        If you're having trouble clicking the button, copy and paste the URL below into your web browser:
-                                        <br/>
-                                        <a th:href="${confirmationUrl}" th:text="${confirmationUrl}" style="color: #3498db; text-decoration: underline;"></a>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
-                    <!-- Footer -->
-                    <tr>
-                        <td align="center" style="padding: 20px 30px; color: #ffffff; background-color: #2c3e50; font-size: 14px;">
-                            &copy; <span th:text="${#dates.year(#dates.createNow())}">2025</span>, <span th:text="${appName}">Data Flow Visualizer</span>. All rights reserved.
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
+<body>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16 text-center">
+    <h2 class="text-2xl font-bold mb-6">Email Verification</h2>
+    <p class="text-gray-300" th:text="${message}"></p>
+    <div class="mt-6">
+        <a th:href="@{/login}" class="font-medium text-cyan-400 hover:text-cyan-300">Back to Login</a>
+    </div>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/faq.html
+++ b/app-web/src/main/resources/templates/faq.html
@@ -1,79 +1,22 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" class="dark">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title>FAQ | Data Flow Visualizer</title>
-    <meta name="description" content="Frequently Asked Questions about the Data Flow Visualizer tool." />
-    <meta name="keywords" content="FAQ, Data Flow Visualizer, Teradata, BTEQ, SQL, ETL, Data Lineage, Support, Help" />
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
-    <link
-      rel="stylesheet"
-      as="style"
-      onload="this.rel='stylesheet'"
-      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
-    />
-    <style>
-        .faq-item {
-            background: rgba(255, 255, 255, 0.05);
-            backdrop-filter: blur(10px);
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            border-radius: 16px;
-            margin-bottom: 1rem;
-            overflow: hidden;
-        }
-        .faq-question {
-            width: 100%;
-            text-align: left;
-            padding: 1.5rem;
-            font-weight: 600;
-            cursor: pointer;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            color: white;
-        }
-        .faq-answer {
-            padding: 0 1.5rem 1.5rem 1.5rem;
-            display: none;
-            color: #e2e8f0;
-        }
-    </style>
+    <title>FAQ</title>
 </head>
-<body style='font-family: Inter, "Noto Sans", sans-serif;'>
-    <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
-        <canvas class="background"></canvas>
-        <div class="layout-container flex h-full grow flex-col">
-            <div th:replace="~{fragments/header :: header}"></div>
-            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
-                <div class="max-w-4xl mx-auto">
-                    <h1 class="text-4xl font-bold text-center text-white mb-12">Frequently Asked Questions</h1>
-                    <div class="space-y-4">
-                        <div th:each="faq : ${faqs}" class="faq-item">
-                            <button class="faq-question">
-                                <span th:text="${faq.question}"></span>
-                                <span>&#9660;</span>
-                            </button>
-                            <div class="faq-answer prose prose-invert max-w-none" th:utext="${faq.answer}">
-                            </div>
-                        </div>
-                        <div th:if="${faqs.isEmpty()}" class="text-center py-10">
-                            <p class="text-gray-400">No FAQs have been published yet. Check back soon!</p>
-                        </div>
-                    </div>
-                </div>
-            </main>
-            <div th:replace="~{fragments/footer :: footer}"></div>
-        </div>
-    </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
-    <script th:src="@{/js/particles-config.js}"></script>
-    <script>
-        document.querySelectorAll('.faq-question').forEach(button => {
-            button.addEventListener('click', () => {
-                const answer = button.nextElementSibling;
-                answer.style.display = answer.style.display === 'block' ? 'none' : 'block';
-            });
-        });
-    </script>
+<body>
+<div th:fragment="content">
+    <section id="faq" class="max-w-3xl mx-auto">
+         <h2 class="text-3xl font-bold text-center mb-12">Frequently Asked Questions</h2>
+         <div class="space-y-4">
+             <details class="glassmorphism rounded-xl p-6 faq-item" th:each="faq : ${faqs}">
+                 <summary>
+                     <span class="font-semibold text-lg" th:text="${faq.question}"></span>
+                     <i class="fas fa-plus icon-plus text-cyan-400 transition-transform"></i>
+                 </summary>
+                 <p class="text-gray-400 mt-4" th:text="${faq.answer}"></p>
+             </details>
+         </div>
+    </section>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/forgot-password.html
+++ b/app-web/src/main/resources/templates/forgot-password.html
@@ -1,28 +1,24 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
     <title>Forgot Password</title>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
 </head>
-<body class="bg-white dark:bg-gray-900">
-    <div th:replace="~{fragments/header :: header}"></div>
-    <div class="form-container">
-        <h2>Forgot Your Password?</h2>
-        <p>Enter your email address and we will send you a link to reset your password.</p>
-        <div th:if="${message}" class="alert alert-success" th:text="${message}"></div>
-        <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
-        <form th:action="@{/forgot-password}" method="post">
-            <div class="form-group">
-                <label for="email">Email:</label>
-                <input type="email" id="email" name="email" required autofocus="autofocus"/>
-            </div>
-            <div>
-                <input type="submit" value="Send Reset Link"/>
-            </div>
-        </form>
-        <p><a th:href="@{/login}">Back to Login</a></p>
+<body>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16">
+    <h2 class="text-2xl font-bold text-center mb-6">Forgot Password</h2>
+    <div th:if="${message}" class="alert alert-info" th:text="${message}"></div>
+    <form th:action="@{/forgot-password}" method="post" class="space-y-6">
+        <div>
+            <label for="email" class="block text-sm font-medium text-gray-300">Enter your email address:</label>
+            <input type="email" id="email" name="email" required autofocus="autofocus" class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+        </div>
+        <div>
+            <input type="submit" value="Send Reset Link" class="w-full px-8 py-3 font-semibold rounded-xl text-black bg-cyan-400 hover:bg-cyan-300 transition-all duration-300 transform hover:scale-105 cursor-pointer"/>
+        </div>
+    </form>
+    <div class="mt-6 text-center">
+        <p><a th:href="@{/login}" class="font-medium text-cyan-400 hover:text-cyan-300">Back to Login</a></p>
     </div>
-    <div th:replace="~{fragments/footer :: footer}"></div>
-    <script th:src="@{/js/theme.js}"></script>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/fragments/common-head.html
+++ b/app-web/src/main/resources/templates/fragments/common-head.html
@@ -1,0 +1,50 @@
+<head th:fragment="head">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #0a0a0a;
+            color: #e5e7eb;
+        }
+        #particles-js {
+            position: fixed;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
+            z-index: -1;
+        }
+        .glassmorphism {
+            background: rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        .hero-glow {
+            box-shadow: 0 0 80px rgba(52, 144, 220, 0.3), 0 0 120px rgba(52, 211, 153, 0.2);
+        }
+        .feature-card:hover {
+            transform: translateY(-8px) scale(1.02);
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+        }
+        .news-card:hover .news-image {
+            transform: scale(1.05);
+        }
+        .faq-item summary {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            cursor: pointer;
+        }
+        .faq-item summary::-webkit-details-marker {
+            display: none;
+        }
+        .faq-item[open] summary .icon-plus {
+            transform: rotate(45deg);
+        }
+    </style>
+</head>

--- a/app-web/src/main/resources/templates/fragments/footer.html
+++ b/app-web/src/main/resources/templates/fragments/footer.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<body>
-<footer th:fragment="footer" class="flex justify-center border-t border-solid border-t-[#f0f3f4] dark:bg-gray-900 dark:border-gray-700 mt-10">
-    <div class="flex max-w-[960px] flex-1 flex-col items-center">
-        <div class="flex gap-6 py-5 text-center">
-            <a th:href="@{/blog}" class="text-sm font-bold leading-normal tracking-[0.015em] text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Blog</a>
-            <a th:href="@{/faq}" class="text-sm font-bold leading-normal tracking-[0.015em] text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">FAQ</a>
-            <a th:href="@{/whats-new}" class="text-sm font-bold leading-normal tracking-[0.015em] text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">What's New</a>
-        </div>
-        <div class="flex flex-col gap-6 px-5 pb-10 text-center">
-            <p class="text-[#618089] dark:text-gray-400 text-base font-normal leading-normal">© 2025 azprojs.net. All rights reserved.</p>
+<footer th:fragment="footer" class="border-t border-white/10 mt-16" xmlns:th="http://www.thymeleaf.org">
+    <div class="max-w-6xl mx-auto px-4 py-8">
+        <div class="flex flex-col md:flex-row justify-between items-center text-center md:text-left space-y-4 md:space-y-0">
+            <p class="text-sm text-gray-400">&copy; 2025 Data Flow Visualizer. All rights reserved.</p>
+            <div class="flex space-x-4">
+                <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-twitter"></i></a>
+                <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-github"></i></a>
+                <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-linkedin"></i></a>
+            </div>
         </div>
     </div>
 </footer>
-</body>
-</html>

--- a/app-web/src/main/resources/templates/fragments/header.html
+++ b/app-web/src/main/resources/templates/fragments/header.html
@@ -1,39 +1,55 @@
-<!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
-<head>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-</head>
-<body>
-
-<header th:fragment="header" class="sticky top-0 z-50 flex items-center whitespace-nowrap border-b border-solid border-white/20 px-10 py-3 bg-gray-900/50 backdrop-blur-lg">
-    <div class="flex items-center gap-4 text-white">
-        <a th:href="@{/}" class="flex items-center gap-4">
-            <img th:src="@{/main-images/icon_full_200x200.png}" alt="Data Flow Visualizer Logo" class="h-8 w-8">
-            <h2 class="text-lg font-bold leading-tight tracking-[-0.015em]">Data Flow Visualizer</h2>
+<header th:fragment="header" id="main-header" class="glassmorphism fixed top-4 left-1/2 -translate-x-1/2 w-[95%] max-w-6xl mx-auto rounded-2xl z-50 transition-all duration-300" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+    <nav class="flex items-center justify-between p-4">
+        <a href="/" class="flex items-center space-x-2">
+            <svg class="h-8 w-8 text-cyan-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1.5-1.5m1.5 1.5l1.5-1.5m3.75-3l-1.5-1.5m1.5 1.5l1.5-1.5m-7.5 3h7.5m-1.5-1.5l-1.5 1.5m1.5-1.5l1.5 1.5M6 6.75h.008v.008H6V6.75z" />
+            </svg>
+            <span class="text-xl font-bold text-white">Data Flow Visualizer</span>
         </a>
-    </div>
 
-    <div class="flex items-center gap-4 ml-auto">
-        <div sec:authorize="isAuthenticated()" class="flex items-center gap-4">
-            <span class="text-gray-300">Welcome, <span sec:authentication="name">User</span>!</span>
-            <a th:href="@{/app}" class="text-sm font-bold leading-normal tracking-[0.015em] text-gray-300 hover:text-white">App</a>
-            <a th:href="@{/suggestions}" class="text-sm font-bold leading-normal tracking-[0.015em] text-gray-300 hover:text-white">Suggestions</a>
-            <a sec:authorize="hasAuthority('ROLE_ADMIN')" th:href="@{/admin}" class="text-sm font-bold leading-normal tracking-[0.015em] text-gray-300 hover:text-white">Admin Panel</a>
-            <form th:action="@{/logout}" method="post" style="display: inline;">
-                <button type="submit" class="text-sm font-bold leading-normal tracking-[0.015em] text-gray-300 hover:text-white bg-transparent border-none cursor-pointer">Logout</button>
-            </form>
+        <div class="hidden md:flex items-center space-x-6 text-sm font-medium mx-auto">
+            <a href="/blog" class="text-gray-300 hover:text-cyan-400 transition-colors">Blog</a>
+            <a href="/faq" class="text-gray-300 hover:text-cyan-400 transition-colors">FAQ</a>
+            <a href="/whats-new" class="text-gray-300 hover:text-cyan-400 transition-colors">What's New</a>
+            <a sec:authorize="isAuthenticated()" th:href="@{/suggestions}" class="text-gray-300 hover:text-cyan-400 transition-colors">Suggestions</a>
+            <a sec:authorize="hasAuthority('ROLE_ADMIN')" th:href="@{/admin}" class="text-gray-300 hover:text-cyan-400 transition-colors">Admin Panel</a>
         </div>
 
-        <div sec:authorize="!isAuthenticated()" class="flex items-center gap-2">
-            <a th:href="@{/register}" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 bg-[#21bded] text-[#111618] text-sm font-bold leading-normal tracking-[0.015em]">
-                <span class="truncate">Register</span>
-            </a>
-            <a th:href="@{/login}" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 bg-gray-700 text-white text-sm font-bold leading-normal tracking-[0.015em]">
-                <span class="truncate">Login</span>
-            </a>
+        <div class="hidden md:flex items-center space-x-3">
+            <div sec:authorize="!isAuthenticated()">
+                <a href="/login" class="px-4 py-2 text-sm font-semibold rounded-lg text-white hover:bg-white/10 transition-colors">Login</a>
+                <a href="/register" class="px-4 py-2 text-sm font-semibold rounded-lg text-black bg-cyan-400 hover:bg-cyan-300 transition-colors">Sign Up</a>
+            </div>
+            <div sec:authorize="isAuthenticated()" class="flex items-center space-x-3">
+                <a th:href="@{/app}" class="px-4 py-2 text-sm font-semibold rounded-lg text-white hover:bg-white/10 transition-colors">App</a>
+                <form th:action="@{/logout}" method="post" style="display: inline;">
+                    <button type="submit" class="px-4 py-2 text-sm font-semibold rounded-lg text-white hover:bg-white/10 transition-colors bg-transparent border-none cursor-pointer">Logout</button>
+                </form>
+            </div>
+        </div>
+        <button id="mobile-menu-button" class="md:hidden text-white">
+            <i class="fas fa-bars fa-lg"></i>
+        </button>
+    </nav>
+    <!-- Mobile Menu -->
+    <div id="mobile-menu" class="hidden md:hidden p-4 border-t border-white/10">
+        <a href="/blog" class="block py-2 text-gray-300 hover:text-cyan-400">Blog</a>
+        <a href="/faq" class="block py-2 text-gray-300 hover:text-cyan-400">FAQ</a>
+        <a href="/whats-new" class="block py-2 text-gray-300 hover:text-cyan-400">What's New</a>
+        <a sec:authorize="isAuthenticated()" th:href="@{/suggestions}" class="block py-2 text-gray-300 hover:text-cyan-400">Suggestions</a>
+        <a sec:authorize="hasAuthority('ROLE_ADMIN')" th:href="@{/admin}" class="block py-2 text-gray-300 hover:text-cyan-400">Admin Panel</a>
+
+        <div class="mt-4 pt-4 border-t border-white/10 space-y-2">
+            <div sec:authorize="!isAuthenticated()">
+                <a href="/login" class="block text-center w-full px-4 py-2 text-sm font-semibold rounded-lg text-white bg-white/10 hover:bg-white/20">Login</a>
+                <a href="/register" class="block text-center w-full px-4 py-2 text-sm font-semibold rounded-lg text-black bg-cyan-400 hover:bg-cyan-300">Sign Up</a>
+            </div>
+            <div sec:authorize="isAuthenticated()">
+                <a th:href="@{/app}" class="block text-center w-full px-4 py-2 text-sm font-semibold rounded-lg text-white bg-white/10 hover:bg-white/20">App</a>
+                <form th:action="@{/logout}" method="post" class="w-full">
+                    <button type="submit" class="w-full px-4 py-2 text-sm font-semibold rounded-lg text-white bg-white/10 hover:bg-white/20">Logout</button>
+                </form>
+            </div>
         </div>
     </div>
 </header>
-
-</body>
-</html>

--- a/app-web/src/main/resources/templates/layout.html
+++ b/app-web/src/main/resources/templates/layout.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en" class="dark" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/common-head :: head}">
+</head>
+<body class="antialiased">
+    <div id="particles-js"></div>
+
+    <header th:replace="~{fragments/header :: header}"></header>
+
+    <main class="pt-32 pb-16 px-4 max-w-6xl mx-auto">
+        <th:block th:include="${view}"></th:block>
+    </main>
+
+    <footer th:replace="~{fragments/footer :: footer}"></footer>
+
+    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+    <script>
+        // Configuración de Particles.js
+        particlesJS('particles-js', {
+            "particles": {
+                "number": {
+                    "value": 50,
+                    "density": {
+                        "enable": true,
+                        "value_area": 800
+                    }
+                },
+                "color": {
+                    "value": "#ffffff"
+                },
+                "shape": {
+                    "type": "circle",
+                },
+                "opacity": {
+                    "value": 0.2,
+                    "random": true,
+                },
+                "size": {
+                    "value": 3,
+                    "random": true,
+                },
+                "line_linked": {
+                    "enable": true,
+                    "distance": 150,
+                    "color": "#ffffff",
+                    "opacity": 0.1,
+                    "width": 1
+                },
+                "move": {
+                    "enable": true,
+                    "speed": 1,
+                    "direction": "none",
+                    "random": false,
+                    "straight": false,
+                    "out_mode": "out",
+                    "bounce": false,
+                }
+            },
+            "interactivity": {
+                "detect_on": "canvas",
+                "events": {
+                    "onhover": {
+                        "enable": true,
+                        "mode": "repulse"
+                    },
+                    "onclick": {
+                        "enable": false
+                    },
+                    "resize": true
+                },
+                "modes": {
+                     "repulse": {
+                        "distance": 100,
+                        "duration": 0.4
+                    }
+                }
+            },
+            "retina_detect": true
+        });
+
+        // Menú móvil
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        if (mobileMenuButton) {
+            mobileMenuButton.addEventListener('click', () => {
+                mobileMenu.classList.toggle('hidden');
+            });
+        }
+
+        // Ocultar header al hacer scroll hacia abajo, mostrar al subir
+        let lastScrollTop = 0;
+        const header = document.getElementById('main-header');
+        if (header) {
+            window.addEventListener('scroll', function() {
+                let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+                if (scrollTop > lastScrollTop && scrollTop > 100) {
+                    // Scroll hacia abajo
+                    header.style.top = '-100px';
+                } else {
+                    // Scroll hacia arriba
+                    header.style.top = '1rem';
+                }
+                lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+            }, false);
+        }
+    </script>
+</body>
+</html>

--- a/app-web/src/main/resources/templates/login.html
+++ b/app-web/src/main/resources/templates/login.html
@@ -1,27 +1,32 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" class="dark">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
     <title>Login</title>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
 </head>
 <body>
-    <div th:replace="~{fragments/header :: header}"></div>
-    <div class="form-container">
-        <h2 class="text-2xl font-bold text-center mb-6">Login</h2>
-        <div th:if="${param.error}" class="alert alert-danger">Invalid username or password.</div>
-        <div th:if="${param.logout}" class="alert alert-info">You have been logged out.</div>
-        <div th:if="${param.verified == 'true'}" class="alert alert-success">Your account has been successfully verified. Please log in.</div>
-        <div th:if="${param.verified == 'false'}" class="alert alert-danger">There was an error during your account verification.</div>
-        <form th:action="@{/login}" method="post" class="space-y-6">
-            <div><label for="username" class="block text-sm font-medium">Username:</label><input type="text" id="username" name="username" autofocus="autofocus" class="w-full"/></div>
-            <div><label for="password" class="block text-sm font-medium">Password:</label><input type="password" id="password" name="password" class="w-full"/></div>
-            <div><input type="submit" value="Log In" class="w-full"/></div>
-        </form>
-        <div class="mt-6 text-center">
-            <p>No account yet? <a th:href="@{/register}" class="font-medium text-blue-400 hover:text-blue-300">Create an account</a></p>
-            <p><a th:href="@{/forgot-password}" class="font-medium text-blue-400 hover:text-blue-300">Forgot Password?</a></p>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16">
+    <h2 class="text-2xl font-bold text-center mb-6">Login</h2>
+    <div th:if="${param.error}" class="alert alert-danger">Invalid username or password.</div>
+    <div th:if="${param.logout}" class="alert alert-info">You have been logged out.</div>
+    <div th:if="${param.verified == 'true'}" class="alert alert-success">Your account has been successfully verified. Please log in.</div>
+    <div th:if="${param.verified == 'false'}" class="alert alert-danger">There was an error during your account verification.</div>
+    <form th:action="@{/login}" method="post" class="space-y-6">
+        <div>
+            <label for="username" class="block text-sm font-medium text-gray-300">Username:</label>
+            <input type="text" id="username" name="username" autofocus="autofocus" class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
         </div>
+        <div>
+            <label for="password" class="block text-sm font-medium text-gray-300">Password:</label>
+            <input type="password" id="password" name="password" class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+        </div>
+        <div>
+            <input type="submit" value="Log In" class="w-full px-8 py-3 font-semibold rounded-xl text-black bg-cyan-400 hover:bg-cyan-300 transition-all duration-300 transform hover:scale-105 cursor-pointer"/>
+        </div>
+    </form>
+    <div class="mt-6 text-center">
+        <p class="text-gray-300">No account yet? <a th:href="@{/register}" class="font-medium text-cyan-400 hover:text-cyan-300">Create an account</a></p>
+        <p><a th:href="@{/forgot-password}" class="font-medium text-cyan-400 hover:text-cyan-300">Forgot Password?</a></p>
     </div>
-    <div th:replace="~{fragments/footer :: footer}"></div>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/password-reset.html
+++ b/app-web/src/main/resources/templates/password-reset.html
@@ -1,74 +1,15 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title th:text="${appName} + ' - Password Reset'"></title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Password Reset</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
-    <table border="0" cellpadding="0" cellspacing="0" width="100%">
-        <tr>
-            <td style="padding: 20px 0 30px 0;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" width="600" style="border-collapse: collapse; border: 1px solid #cccccc; background-color: #ffffff;">
-                    <!-- Header -->
-                    <tr>
-                        <td align="center" style="padding: 40px 0 30px 0; color: #2c3e50; font-size: 28px; font-weight: bold; border-bottom: 1px solid #cccccc;">
-                            <span th:text="${appName}">Data Flow Visualizer</span>
-                        </td>
-                    </tr>
-                    <!-- Body -->
-                    <tr>
-                        <td style="padding: 40px 30px 40px 30px;">
-                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                <tr>
-                                    <td style="color: #333333; font-size: 20px; font-weight: bold;">
-                                        Password Reset Request
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style="padding: 20px 0 30px 0; color: #555555; font-size: 16px; line-height: 1.5;">
-                                        Hello <span th:text="${userName}">User</span>,
-                                        <br/><br/>
-                                        A request has been received to change the password for your <strong th:text="${appName}"></strong> account.
-                                        <br/><br/>
-                                        Please click the button below to reset your password.
-                                    </td>
-                                </tr>
-                                <!-- CTA Button -->
-                                <tr>
-                                    <td align="center">
-                                        <table border="0" cellpadding="0" cellspacing="0">
-                                            <tr>
-                                                <td align="center" style="border-radius: 5px;" bgcolor="#3498db">
-                                                    <a th:href="${resetUrl}" target="_blank" style="font-size: 16px; color: #ffffff; text-decoration: none; padding: 15px 25px; border-radius: 5px; display: inline-block; font-weight: bold;">
-                                                        Reset Your Password
-                                                    </a>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </td>
-                                </tr>
-                                 <tr>
-                                    <td style="padding: 30px 0 0 0; color: #888888; font-size: 14px;">
-                                        If you did not request a password reset, please ignore this email.
-                                        <br/><br/>
-                                        If you're having trouble clicking the button, copy and paste the URL below into your web browser:
-                                        <br/>
-                                        <a th:href="${resetUrl}" th:text="${resetUrl}" style="color: #3498db; text-decoration: underline;"></a>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
-                    <!-- Footer -->
-                    <tr>
-                        <td align="center" style="padding: 20px 30px; color: #ffffff; background-color: #2c3e50; font-size: 14px;">
-                            &copy; <span th:text="${#dates.year(#dates.createNow())}">2025</span>, <span th:text="${appName}">Data Flow Visualizer</span>. All rights reserved.
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
+<body>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16 text-center">
+    <h2 class="text-2xl font-bold mb-6">Password Reset</h2>
+    <p class="text-gray-300" th:text="${message}"></p>
+    <div class="mt-6">
+        <a th:href="@{/login}" class="font-medium text-cyan-400 hover:text-cyan-300">Back to Login</a>
+    </div>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/register.html
+++ b/app-web/src/main/resources/templates/register.html
@@ -1,36 +1,35 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" class="dark">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
     <title>Register</title>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
 </head>
 <body>
-    <div th:replace="~{fragments/header :: header}"></div>
-    <div class="form-container">
-        <h2 class="text-2xl font-bold text-center mb-6">Create an Account</h2>
-        <div th:if="${message}" class="alert alert-success" th:text="${message}"></div>
-        <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
-        <form th:action="@{/register}" th:object="${user}" method="post" class="space-y-6">
-            <div>
-                <label for="username" class="block text-sm font-medium">Username:</label>
-                <input type="text" id="username" th:field="*{username}" required autofocus="autofocus" class="w-full"/>
-            </div>
-            <div>
-                <label for="email" class="block text-sm font-medium">Email:</label>
-                <input type="email" id="email" th:field="*{email}" required class="w-full"/>
-            </div>
-            <div>
-                <label for="password" class="block text-sm font-medium">Password:</label>
-                <input type="password" id="password" th:field="*{password}" required class="w-full"/>
-            </div>
-            <div>
-                <input type="submit" value="Register" class="w-full"/>
-            </div>
-        </form>
-        <div class="mt-6 text-center">
-            <p>Already have an account? <a th:href="@{/login}" class="font-medium text-blue-400 hover:text-blue-300">Log in</a></p>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16">
+    <h2 class="text-2xl font-bold text-center mb-6">Create Account</h2>
+    <div th:if="${param.error}" class="alert alert-danger">Something went wrong.</div>
+    <form th:action="@{/register}" th:object="${user}" method="post" class="space-y-6">
+        <div>
+            <label for="username" class="block text-sm font-medium text-gray-300">Username:</label>
+            <input type="text" id="username" th:field="*{username}" required autofocus="autofocus" class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+            <p th:if="${#fields.hasErrors('username')}" th:errors="*{username}" class="text-red-500 text-xs mt-1"></p>
         </div>
+        <div>
+            <label for="email" class="block text-sm font-medium text-gray-300">Email:</label>
+            <input type="email" id="email" th:field="*{email}" required class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+            <p th:if="${#fields.hasErrors('email')}" th:errors="*{email}" class="text-red-500 text-xs mt-1"></p>
+        </div>
+        <div>
+            <label for="password" class="block text-sm font-medium text-gray-300">Password:</label>
+            <input type="password" id="password" th:field="*{password}" required class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+            <p th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="text-red-500 text-xs mt-1"></p>
+        </div>
+        <div>
+            <input type="submit" value="Register" class="w-full px-8 py-3 font-semibold rounded-xl text-black bg-cyan-400 hover:bg-cyan-300 transition-all duration-300 transform hover:scale-105 cursor-pointer"/>
+        </div>
+    </form>
+    <div class="mt-6 text-center">
+        <p class="text-gray-300">Already have an account? <a th:href="@{/login}" class="font-medium text-cyan-400 hover:text-cyan-300">Log in</a></p>
     </div>
-    <div th:replace="~{fragments/footer :: footer}"></div>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/reset-password.html
+++ b/app-web/src/main/resources/templates/reset-password.html
@@ -1,27 +1,26 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <meta charset="UTF-8">
     <title>Reset Password</title>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
 </head>
-<body class="bg-white dark:bg-gray-900">
-<div th:replace="~{fragments/header :: header}"></div>
-<div class="form-container">
-    <h2>Choose a New Password</h2>
+<body>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16">
+    <h2 class="text-2xl font-bold text-center mb-6">Reset Your Password</h2>
     <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
-    <form th:action="@{/reset-password}" method="post">
+    <form th:action="@{/reset-password}" method="post" class="space-y-6">
         <input type="hidden" name="token" th:value="${token}" />
-        <div class="form-group">
-            <label for="password">New Password:</label>
-            <input type="password" id="password" name="password" required autofocus="autofocus"/>
+        <div>
+            <label for="password" class="block text-sm font-medium text-gray-300">New Password:</label>
+            <input type="password" id="password" name="password" required autofocus="autofocus" class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
         </div>
         <div>
-            <input type="submit" value="Reset Password"/>
+            <label for="confirmPassword" class="block text-sm font-medium text-gray-300">Confirm New Password:</label>
+            <input type="password" id="confirmPassword" name="confirmPassword" required class="w-full bg-white/10 rounded-lg text-white px-4 py-2 mt-2 focus:outline-none focus:ring-2 focus:ring-cyan-400"/>
+        </div>
+        <div>
+            <input type="submit" value="Reset Password" class="w-full px-8 py-3 font-semibold rounded-xl text-black bg-cyan-400 hover:bg-cyan-300 transition-all duration-300 transform hover:scale-105 cursor-pointer"/>
         </div>
     </form>
 </div>
-<div th:replace="~{fragments/footer :: footer}"></div>
-<script th:src="@{/js/theme.js}"></script>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/suggestions.html
+++ b/app-web/src/main/resources/templates/suggestions.html
@@ -1,26 +1,14 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title>Submit a Suggestion</title>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
+    <title>Suggestions</title>
 </head>
-<body class="bg-white dark:bg-gray-900">
-    <div th:replace="~{fragments/header :: header}"></div>
-    <div class="form-container">
-        <h1>Submit a Suggestion</h1>
-        <p>We appreciate your feedback! Please let us know how we can improve the application.</p>
-
-        <div th:if="${message}" class="alert-success" th:text="${message}"></div>
-
-        <form th:action="@{/suggestions}" method="post">
-            <div class="form-group">
-                <label for="suggestionText">Your Suggestion:</label>
-                <textarea id="suggestionText" name="suggestionText" required></textarea>
-            </div>
-            <button type="submit" class="btn-primary">Submit</button>
-        </form>
+<body>
+<div th:fragment="content" class="glassmorphism rounded-3xl p-8 md:p-16">
+    <h2 class="text-2xl font-bold text-center mb-6">Suggestions</h2>
+    <div class="text-gray-300">
+        <p>Here you can leave your suggestions to improve the application.</p>
     </div>
-    <div th:replace="~{fragments/footer :: footer}"></div>
-    <script th:src="@{/js/theme.js}"></script>
+</div>
 </body>
 </html>

--- a/app-web/src/main/resources/templates/whats-new.html
+++ b/app-web/src/main/resources/templates/whats-new.html
@@ -1,44 +1,20 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" class="dark">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: html(view=~{::content})}">
 <head>
-    <title>What's New | Data Flow Visualizer</title>
-    <meta name="description" content="Latest updates and new features of the Data Flow Visualizer tool." />
-    <meta name="keywords" content="What's New, Updates, Features, Data Flow Visualizer, Teradata, BTEQ, SQL, ETL, Data Lineage" />
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
-    <link
-      rel="stylesheet"
-      as="style"
-      onload="this.rel='stylesheet'"
-      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
-    />
+    <title>What's New</title>
 </head>
-<body style='font-family: Inter, "Noto Sans", sans-serif;'>
-    <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
-        <canvas class="background"></canvas>
-        <div class="layout-container flex h-full grow flex-col">
-            <div th:replace="~{fragments/header :: header}"></div>
-            <main class="flex-1 justify-center py-20 px-4 sm:px-6 lg:px-8">
-                <div class="max-w-4xl mx-auto">
-                    <h1 class="text-4xl font-bold text-center text-white mb-12">What's New</h1>
-                    <div class="space-y-12">
-                        <div th:each="item : ${whatsnews}" class="feature-card">
-                            <h2 class="text-2xl font-bold text-white mb-2" th:text="${item.title}"></h2>
-                            <div class="text-sm text-gray-400 mb-4">
-                                <span>Published on <span th:text="${#temporals.format(item.createdAt, 'MMMM dd, yyyy')}">Date</span></span>
-                            </div>
-                            <div class="prose prose-invert max-w-none" th:utext="${item.content}"></div>
-                        </div>
-                        <div th:if="${whatsnews.isEmpty()}" class="text-center py-10">
-                            <p class="text-gray-400">No updates have been published yet. Check back soon!</p>
-                        </div>
-                    </div>
-                </div>
-            </main>
-            <div th:replace="~{fragments/footer :: footer}"></div>
+<body>
+<div th:fragment="content">
+    <section id="whats-new" class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold text-center mb-12">What's New</h2>
+        <div class="space-y-4">
+            <div class="glassmorphism rounded-xl p-6" th:each="item : ${whatsNewItems}">
+                <h3 class="text-xl font-bold mb-2" th:text="${item.title}"></h3>
+                <p class="text-gray-400" th:text="${item.content}"></p>
+                <span class="text-xs text-gray-500" th:text="${#dates.format(item.date, 'dd-MM-yyyy')}"></span>
+            </div>
         </div>
-    </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/particlesjs/2.2.3/particles.min.js"></script>
-    <script th:src="@{/js/particles-config.js}"></script>
+    </section>
+</div>
 </body>
 </html>


### PR DESCRIPTION
This commit applies the modern visual appearance and effects of the home.html page to all other pages of the application to create a consistent user experience.

A new `layout.html` file has been created to define the main structure of the pages. This layout includes the header, footer, and the particle background.

A `common-head.html` fragment has been created to centralize common styles and scripts, such as Tailwind CSS, Google Fonts, Font Awesome, and custom styles.

The header and footer fragments have been refactored to reflect the new visual style. The header now supports both authenticated and unauthenticated users.

All pages have been updated to use the new layout, ensuring a consistent and professional look and feel across the entire application. This was done by using `th:replace` to include the layout and a `th:fragment` to inject the content of each page.