### PR TITLE
feat: Expand ANTLR grammar and refactor parser to use DTOs

### DIFF
--- a/parser-service/src/main/antlr4/com/tdtsqlscan/parser/antlr/Bteq.g4
+++ b/parser-service/src/main/antlr4/com/tdtsqlscan/parser/antlr/Bteq.g4
@@ -2,43 +2,111 @@ grammar Bteq;
 
 // Top-level rule for a BTEQ script
 script
-    : (bteq_command | sql_statement)* EOF
+    : (statement)* EOF
+    ;
+
+statement
+    : bteq_command
+    | sql_statement
     ;
 
 // A statement can be a BTEQ command or a SQL statement
 bteq_command
-    : logon_command
+    : (logon_command
     | logoff_command
+    | export_reset_command
+    | export_file_command
+    | set_width_command
+    | if_errorcode_goto_command) SEMICOLON
     ;
 
+// Differentiates between high-level SQL statement types
 sql_statement
-    : content_up_to_semicolon SEMICOLON
+    : (dml_statement | ddl_statement) SEMICOLON
     ;
 
-// Specific BTEQ commands
+// --- BTEQ Command Rules ---
+
 logon_command
-    : LOGON content_up_to_semicolon SEMICOLON
+    : LOGON text_up_to_semicolon
     ;
 
 logoff_command
-    : LOGOFF SEMICOLON
+    : LOGOFF
     ;
 
+export_reset_command
+    : EXPORT RESET
+    ;
+
+export_file_command
+    : EXPORT FILE '=' path=STRING
+    ;
+
+set_width_command
+    : SET WIDTH width=NUMBER
+    ;
+
+if_errorcode_goto_command
+    : IF ERRORCODE operator=OPERATOR code=NUMBER THEN GOTO label=IDENTIFIER
+    ;
+
+
+// --- SQL Statement Rules ---
+
+dml_statement
+    : (SELECT | INSERT | UPDATE | DELETE) text_up_to_semicolon
+    ;
+
+ddl_statement
+    : (CREATE | DROP) TABLE text_up_to_semicolon
+    ;
+
+
+// --- Generic Helper Rules ---
+
 // This rule will consume any tokens until it sees a semicolon.
-// This is used for the body of the LOGON command and for any SQL statement.
-content_up_to_semicolon
+text_up_to_semicolon
     : (~SEMICOLON)*
     ;
 
-// Lexer Rules - these define the tokens
+
+// --- Lexer Rules ---
+
+// BTEQ Keywords
 LOGON: '.' [Ll][Oo][Gg][Oo][Nn];
 LOGOFF: '.' [Ll][Oo][Gg][Oo][Ff][Ff];
+EXPORT: '.' [Ee][Xx][Pp][Oo][Rr][Tt];
+SET: '.' [Ss][Ee][Tt];
+IF: '.' [Ii][Ff];
+GOTO: '.' [Gg][Oo][Tt][Oo];
 
+// BTEQ Parameters & Keywords
+RESET: [Rr][Ee][Ss][Ee][Tt];
+FILE: [Ff][Ii][Ll][Ee];
+WIDTH: [Ww][Ii][Dd][Tt][Hh];
+ERRORCODE: [Ee][Rr][Rr][Oo][Rr][Cc][Oo][Dd][Ee];
+THEN: [Tt][Hh][Ee][Nn];
+
+// SQL Keywords
+SELECT: [Ss][Ee][Ll][Ee][Cc][Tt];
+INSERT: [Ii][Nn][Ss][Ee][Rr][Tt];
+UPDATE: [Uu][Pp][Dd][Aa][Tt][Ee];
+DELETE: [Dd][Ee][Ll][Ee][Tt][Ee];
+CREATE: [Cc][Rr][Ee][Aa][Tt][Ee];
+DROP: [Dd][Rr][Oo][Pp];
+TABLE: [Tt][Aa][Bb][Ll][Ee];
+
+// Basic Tokens
 SEMICOLON: ';';
+EQUALS: '=';
+OPERATOR: '<>' | '!=' | '>' | '<' | '>=' | '<=';
+NUMBER: [0-9]+;
+IDENTIFIER: [a-zA-Z_][a-zA-Z0-9_]*;
+STRING: '\'' (~'\'')* '\'' | '"' (~'"')* '"'; // Handles single or double quoted strings
 
-// Any other text is just treated as generic content at the lexer level.
-// The parser rules will give it meaning.
-CONTENT: ~[; \t\r\n]+;
+// Any other text is intentionally not captured by a catch-all rule.
+// The text_up_to_semicolon parser rule will consume tokens until it hits a semicolon.
 
 // Whitespace is skipped
 WS: [ \t\r\n]+ -> skip;

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/AntlrBteqParserService.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/AntlrBteqParserService.java
@@ -2,18 +2,17 @@ package com.tdtsqlscan.parser;
 
 import com.tdtsqlscan.parser.antlr.BteqLexer;
 import com.tdtsqlscan.parser.antlr.BteqParser;
+import com.tdtsqlscan.parser.dto.ParseResultDto;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 public class AntlrBteqParserService {
 
-    public List<String> parse(String scriptContent) {
+    public ParseResultDto parse(String scriptContent) {
         // Create a CharStream from the script content
         BteqLexer lexer = new BteqLexer(CharStreams.fromString(scriptContent));
 
@@ -32,7 +31,7 @@ public class AntlrBteqParserService {
         // Walk the tree with the listener
         ParseTreeWalker.DEFAULT.walk(listener, tree);
 
-        // Return the extracted commands
-        return listener.getCommands();
+        // Return the structured parse result
+        return listener.getParseResult();
     }
 }

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/BteqScriptListener.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/BteqScriptListener.java
@@ -2,39 +2,127 @@ package com.tdtsqlscan.parser;
 
 import com.tdtsqlscan.parser.antlr.BteqBaseListener;
 import com.tdtsqlscan.parser.antlr.BteqParser;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.TerminalNode;
+import com.tdtsqlscan.parser.dto.ParseResultDto;
+import com.tdtsqlscan.parser.dto.StatementDto;
+import com.tdtsqlscan.parser.dto.StatementType;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.misc.Interval;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.Map;
 
 public class BteqScriptListener extends BteqBaseListener {
 
-    private final List<String> commands = new ArrayList<>();
+    private final ParseResultDto parseResult = new ParseResultDto();
 
-    public List<String> getCommands() {
-        return commands;
+    public ParseResultDto getParseResult() {
+        return parseResult;
+    }
+
+    private String getOriginalText(ParserRuleContext ctx) {
+        if (ctx == null || ctx.getStart() == null || ctx.getStop() == null) {
+            return ""; // Should not happen in a valid parse
+        }
+        CharStream inputStream = ctx.getStart().getInputStream();
+        int startIndex = ctx.getStart().getStartIndex();
+        int stopIndex = ctx.getStop().getStopIndex();
+
+        if (inputStream == null || startIndex > stopIndex) {
+             // Fallback for safety, though this indicates a bigger problem
+             return ctx.getText();
+        }
+
+        return inputStream.getText(new Interval(startIndex, stopIndex));
     }
 
     @Override
     public void enterLogon_command(BteqParser.Logon_commandContext ctx) {
-        String commandText = ctx.LOGON().getText();
-        String content = ctx.content_up_to_semicolon().getText();
-        commands.add("LOGON: " + commandText + content);
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.BTEQ_COMMAND);
+        stmt.setCommandName("LOGON");
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        stmt.setDetails(new HashMap<>());
+        parseResult.addStatement(stmt);
     }
 
     @Override
     public void enterLogoff_command(BteqParser.Logoff_commandContext ctx) {
-        commands.add("LOGOFF: " + ctx.LOGOFF().getText());
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.BTEQ_COMMAND);
+        stmt.setCommandName("LOGOFF");
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        stmt.setDetails(new HashMap<>());
+        parseResult.addStatement(stmt);
     }
 
     @Override
-    public void enterSql_statement(BteqParser.Sql_statementContext ctx) {
-        // We need to reconstruct the SQL statement from the tokens
-        String sql = ctx.content_up_to_semicolon().children.stream()
-                .map(ParseTree::getText)
-                .collect(Collectors.joining(" "));
-        commands.add("SQL: " + sql.trim());
+    public void enterExport_reset_command(BteqParser.Export_reset_commandContext ctx) {
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.BTEQ_COMMAND);
+        stmt.setCommandName("EXPORT RESET");
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        stmt.setDetails(new HashMap<>());
+        parseResult.addStatement(stmt);
+    }
+
+    @Override
+    public void enterExport_file_command(BteqParser.Export_file_commandContext ctx) {
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.BTEQ_COMMAND);
+        stmt.setCommandName("EXPORT FILE");
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        Map<String, String> details = new HashMap<>();
+        String path = ctx.path.getText();
+        details.put("filePath", path.substring(1, path.length() - 1));
+        stmt.setDetails(details);
+        parseResult.addStatement(stmt);
+    }
+
+    @Override
+    public void enterSet_width_command(BteqParser.Set_width_commandContext ctx) {
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.BTEQ_COMMAND);
+        stmt.setCommandName("SET WIDTH");
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        Map<String, String> details = new HashMap<>();
+        details.put("width", ctx.width.getText());
+        stmt.setDetails(details);
+        parseResult.addStatement(stmt);
+    }
+
+    @Override
+    public void enterIf_errorcode_goto_command(BteqParser.If_errorcode_goto_commandContext ctx) {
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.BTEQ_COMMAND);
+        stmt.setCommandName("IF ERRORCODE GOTO");
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        Map<String, String> details = new HashMap<>();
+        details.put("operator", ctx.operator.getText());
+        details.put("code", ctx.code.getText());
+        details.put("label", ctx.label.getText());
+        stmt.setDetails(details);
+        parseResult.addStatement(stmt);
+    }
+
+    @Override
+    public void enterDml_statement(BteqParser.Dml_statementContext ctx) {
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.SQL_DML);
+        stmt.setCommandName(ctx.getChild(0).getText().toUpperCase());
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        stmt.setDetails(new HashMap<>());
+        parseResult.addStatement(stmt);
+    }
+
+    @Override
+    public void enterDdl_statement(BteqParser.Ddl_statementContext ctx) {
+        StatementDto stmt = new StatementDto();
+        stmt.setType(StatementType.SQL_DDL);
+        String command = ctx.getChild(0).getText().toUpperCase() + " " + ctx.getChild(1).getText().toUpperCase();
+        stmt.setCommandName(command);
+        stmt.setRawContent(getOriginalText(ctx.getParent()));
+        stmt.setDetails(new HashMap<>());
+        parseResult.addStatement(stmt);
     }
 }

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/PocParserController.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/PocParserController.java
@@ -1,13 +1,12 @@
 package com.tdtsqlscan.parser;
 
+import com.tdtsqlscan.parser.dto.ParseResultDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/parse")
@@ -21,11 +20,11 @@ public class PocParserController {
     }
 
     @PostMapping("/poc")
-    public ResponseEntity<List<String>> parseScript(@RequestBody ParseRequest request) {
+    public ResponseEntity<ParseResultDto> parseScript(@RequestBody ParseRequest request) {
         if (request == null || request.getScriptContent() == null || request.getScriptContent().isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
-        List<String> commands = parserService.parse(request.getScriptContent());
-        return ResponseEntity.ok(commands);
+        ParseResultDto result = parserService.parse(request.getScriptContent());
+        return ResponseEntity.ok(result);
     }
 }

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/dto/ParseResultDto.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/dto/ParseResultDto.java
@@ -1,0 +1,27 @@
+package com.tdtsqlscan.parser.dto;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class ParseResultDto {
+
+    private List<StatementDto> statements;
+
+    public ParseResultDto() {
+        this.statements = new ArrayList<>();
+    }
+
+    // Getters and Setters
+
+    public List<StatementDto> getStatements() {
+        return statements;
+    }
+
+    public void setStatements(List<StatementDto> statements) {
+        this.statements = statements;
+    }
+
+    public void addStatement(StatementDto statement) {
+        this.statements.add(statement);
+    }
+}

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/dto/StatementDto.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/dto/StatementDto.java
@@ -1,0 +1,45 @@
+package com.tdtsqlscan.parser.dto;
+
+import java.util.Map;
+
+public class StatementDto {
+
+    private StatementType type;
+    private String commandName;
+    private String rawContent;
+    private Map<String, String> details;
+
+    // Getters and Setters
+
+    public StatementType getType() {
+        return type;
+    }
+
+    public void setType(StatementType type) {
+        this.type = type;
+    }
+
+    public String getCommandName() {
+        return commandName;
+    }
+
+    public void setCommandName(String commandName) {
+        this.commandName = commandName;
+    }
+
+    public String getRawContent() {
+        return rawContent;
+    }
+
+    public void setRawContent(String rawContent) {
+        this.rawContent = rawContent;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
+    }
+}

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/dto/StatementType.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/dto/StatementType.java
@@ -1,0 +1,7 @@
+package com.tdtsqlscan.parser.dto;
+
+public enum StatementType {
+    BTEQ_COMMAND,
+    SQL_DML,
+    SQL_DDL
+}

--- a/send_request.py
+++ b/send_request.py
@@ -1,0 +1,29 @@
+import json
+import requests
+
+with open('test_full.bteq', 'r') as f:
+    script_content = f.read()
+
+payload = {
+    "script_content": script_content
+}
+
+try:
+    response = requests.post(
+        "http://localhost:8080/api/v1/parse/poc",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps(payload)
+    )
+    print(f"Status Code: {response.status_code}")
+    print("Response Text:")
+    print(response.text)
+    if response.status_code == 200:
+        print("\nResponse JSON:")
+        # Pretty print the JSON
+        parsed_json = json.loads(response.text)
+        print(json.dumps(parsed_json, indent=4))
+
+except requests.exceptions.ConnectionError as e:
+    print(f"Connection Error: {e}")
+except Exception as e:
+    print(f"An error occurred: {e}")

--- a/test_full.bteq
+++ b/test_full.bteq
@@ -1,0 +1,26 @@
+.LOGON 192.168.1.1/testuser,testpass;
+.SET WIDTH 120;
+.EXPORT RESET;
+.EXPORT FILE = '/var/data/today.csv';
+
+SELECT
+    column_a,
+    column_b,
+    column_c
+FROM my_table
+WHERE column_a > 100;
+
+INSERT INTO another_table (col1, col2) VALUES ('value1', 'value2');
+
+.IF ERRORCODE <> 0 THEN .GOTO handle_error;
+
+DELETE FROM my_table WHERE column_b = 'some_value';
+
+CREATE TABLE new_temp_table (
+    id INTEGER,
+    name VARCHAR(100)
+);
+
+DROP TABLE old_temp_table;
+
+.LOGOFF;


### PR DESCRIPTION
This commit significantly enhances the BTEQ parser service by:

1.  **Expanding the ANTLR grammar (Bteq.g4):**
    *   Added explicit rules for `.EXPORT RESET`, `.EXPORT FILE`, `.SET WIDTH`, and `.IF ERRORCODE`.
    *   Differentiated high-level SQL statements (SELECT, INSERT, UPDATE, DELETE, CREATE TABLE, DROP TABLE).

2.  **Introducing Typed DTOs:**
    *   Replaced the `List<String>` output with a structured `ParseResultDto`.
    *   Created `StatementDto` to represent each command/statement with its type, name, raw content, and extracted metadata.
    *   This fulfills the FR-01.3 requirement for a normalized JSON output.

3.  **Refactoring the Service Layer:**
    *   Updated the `AntlrBteqParserService`, `BteqScriptListener`, and `PocParserController` to produce and handle the new DTO structure.
    *   The listener now correctly populates the DTOs with parsed information.

This change moves the parser from a simple proof-of-concept to a more robust service that provides a structured, machine-readable representation of the input script, laying the groundwork for future in-depth analysis.