### PR TITLE
feat(parser-service): Definir y Aplicar un Contrato OpenAPI (Swagger)

### DIFF
--- a/parser-service/pom.xml
+++ b/parser-service/pom.xml
@@ -32,6 +32,16 @@
             <artifactId>antlr4-runtime</artifactId>
             <version>${antlr.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+            <version>2.2.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/PocParserController.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/PocParserController.java
@@ -1,7 +1,13 @@
 package com.tdtsqlscan.parser;
 
 import com.tdtsqlscan.parser.dto.ParseResultDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/parse")
+@Tag(name = "Parser POC", description = "Endpoints para el Proof of Concept del servicio de parsing")
 public class PocParserController {
 
     private final AntlrBteqParserService parserService;
@@ -19,7 +26,27 @@ public class PocParserController {
         this.parserService = parserService;
     }
 
-    @PostMapping("/poc")
+    @PostMapping(value = "/poc", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Analiza un script BTEQ",
+            description = "Recibe un script BTEQ en formato de texto plano dentro de un objeto JSON, lo procesa y devuelve una estructura detallada de las sentencias encontradas."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Objeto JSON que contiene el script BTEQ a analizar.",
+            required = true,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ParseRequest.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Análisis exitoso.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ParseResultDto.class)
+            )
+    )
     public ResponseEntity<ParseResultDto> parseScript(@RequestBody ParseRequest request) {
         if (request == null || request.getScriptContent() == null || request.getScriptContent().isEmpty()) {
             return ResponseEntity.badRequest().build();

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/dto/ParseResultDto.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/dto/ParseResultDto.java
@@ -1,10 +1,13 @@
 package com.tdtsqlscan.parser.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.ArrayList;
 
+@Schema(description = "Representa el resultado completo del análisis de un script, conteniendo una lista de todas las sentencias y comandos identificados.")
 public class ParseResultDto {
 
+    @Schema(description = "La lista de sentencias y comandos extraídos del script.")
     private List<StatementDto> statements;
 
     public ParseResultDto() {

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/dto/StatementDto.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/dto/StatementDto.java
@@ -1,12 +1,18 @@
 package com.tdtsqlscan.parser.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Map;
 
+@Schema(description = "Representa una única sentencia o comando extraído de un script BTEQ.")
 public class StatementDto {
 
+    @Schema(description = "El tipo de sentencia (ej. DDL, DML, CONTROL, SQL).")
     private StatementType type;
+    @Schema(description = "El nombre específico del comando (ej. 'CREATE TABLE', '.IF', 'SELECT').")
     private String commandName;
+    @Schema(description = "El texto completo y sin modificar de la sentencia o comando detectado.")
     private String rawContent;
+    @Schema(description = "Un mapa de clave-valor con detalles extraídos de la sentencia, como nombres de tabla, condiciones, etc.")
     private Map<String, String> details;
 
     // Getters and Setters

--- a/parser-service/src/main/resources/application.properties
+++ b/parser-service/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.info.title=TDT SQL Scan - Parser Service API
+springdoc.info.version=v0.1.0
+springdoc.info.description=API para el análisis sintáctico de scripts SQL y BTEQ.


### PR DESCRIPTION
Integra springdoc-openapi en el servicio de parsing para formalizar el contrato de la API.

- Añade la dependencia `springdoc-openapi-starter-webmvc-ui` y `swagger-annotations-jakarta` al pom.xml.
- Configura la información de la API (título, versión, descripción) en `application.properties`.
- Anota el `PocParserController` con anotaciones de OpenAPI para describir el endpoint POST /api/v1/parse/poc.
- Anota los DTOs `ParseResultDto` y `StatementDto` con @Schema para proporcionar descripciones claras de los modelos de datos.

Esto habilita la generación de documentación interactiva a través de Swagger UI, facilitando el desarrollo en paralelo y la integración con otros servicios.