### PR TITLE
feat(parser-service): Secure Parser Service with Spring Security

### DIFF
--- a/parser-service/pom.xml
+++ b/parser-service/pom.xml
@@ -42,6 +42,18 @@
             <artifactId>swagger-annotations-jakarta</artifactId>
             <version>2.2.9</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/ParseRequest.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/ParseRequest.java
@@ -1,10 +1,14 @@
 package com.tdtsqlscan.parser;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class ParseRequest {
 
     @JsonProperty("script_content")
+    @NotBlank
+    @Size(max = 50000)
     private String scriptContent;
 
     public String getScriptContent() {

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/PocParserController.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/PocParserController.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/parse")
 @Tag(name = "Parser POC", description = "Endpoints para el Proof of Concept del servicio de parsing")
+@SecurityRequirement(name = "bearerAuth")
 public class PocParserController {
 
     private final AntlrBteqParserService parserService;
@@ -47,10 +50,7 @@ public class PocParserController {
                     schema = @Schema(implementation = ParseResultDto.class)
             )
     )
-    public ResponseEntity<ParseResultDto> parseScript(@RequestBody ParseRequest request) {
-        if (request == null || request.getScriptContent() == null || request.getScriptContent().isEmpty()) {
-            return ResponseEntity.badRequest().build();
-        }
+    public ResponseEntity<ParseResultDto> parseScript(@Valid @RequestBody ParseRequest request) {
         ParseResultDto result = parserService.parse(request.getScriptContent());
         return ResponseEntity.ok(result);
     }

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/config/OpenAPIConfig.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/config/OpenAPIConfig.java
@@ -1,0 +1,15 @@
+package com.tdtsqlscan.parser.config;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer"
+)
+public class OpenAPIConfig {
+}

--- a/parser-service/src/main/java/com/tdtsqlscan/parser/config/SecurityConfig.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.tdtsqlscan.parser.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
+                                .requestMatchers("/api/v1/**").hasAuthority("SCOPE_parser:parse")
+                                .anyRequest().denyAll()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}

--- a/parser-service/src/main/resources/application.properties
+++ b/parser-service/src/main/resources/application.properties
@@ -3,3 +3,5 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.info.title=TDT SQL Scan - Parser Service API
 springdoc.info.version=v0.1.0
 springdoc.info.description=API para el análisis sintáctico de scripts SQL y BTEQ.
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9000


### PR DESCRIPTION
Implement the Parser Service as an OAuth2 Resource Server to enforce a "zero trust" security model as per requirement FR-05.

This change introduces the following:
- Adds Spring Security, OAuth2 Resource Server, and Validation dependencies.
- Configures a SecurityFilterChain to protect all endpoints under /api/v1/**.
- Endpoints now require a valid JWT with the "parser:parse" scope.
- Adds the `spring.security.oauth2.resourceserver.jwt.issuer-uri` property to `application.properties` for JWT signature verification.
- Implements input validation on the `ParseRequest` DTO to prevent denial-of-service attacks from overly large or empty inputs.
- Updates the OpenAPI documentation to reflect the new security requirements, adding a bearerAuth security scheme and marking the controller as secured. This allows developers to authorize requests in the Swagger UI.
- Allows public access to Swagger UI and API docs endpoints for ease of development and testing.