### PR TITLE
Refactor: Estrangular BteqUploadController para usar Parser Service

### DIFF
--- a/app-web/pom.xml
+++ b/app-web/pom.xml
@@ -95,6 +95,15 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/app-web/src/main/java/com/tdtsqlscan/web/BteqUploadController.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/BteqUploadController.java
@@ -1,32 +1,14 @@
 package com.tdtsqlscan.web;
 
-import com.tdtsqlscan.core.QueryParser;
-import com.tdtsqlscan.ddl.CreateIndexParser;
-import com.tdtsqlscan.ddl.CreateTableParser;
-import com.tdtsqlscan.ddl.DropTableParser;
-import com.tdtsqlscan.dml.DeleteParser;
-import com.tdtsqlscan.dml.InsertParser;
-import com.tdtsqlscan.dml.UpdateParser;
-import com.tdtsqlscan.etl.BteqScript;
-import com.tdtsqlscan.etl.BteqScriptParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tdtsqlscan.core.SQLParserUtils;
-import com.tdtsqlscan.core.SQLQuery;
-import com.tdtsqlscan.core.SQLTableRef;
-import com.tdtsqlscan.ddl.CreateTableQuery;
-import com.tdtsqlscan.ddl.DropTableQuery;
-import com.tdtsqlscan.dml.DeleteQuery;
-import com.tdtsqlscan.dml.InsertQuery;
-import com.tdtsqlscan.dml.UpdateQuery;
-import com.tdtsqlscan.etl.BteqCommand;
-import com.tdtsqlscan.etl.BteqSqlCommand;
 import com.tdtsqlscan.graph.Graph;
-import com.tdtsqlscan.select.SelectParser;
-import com.tdtsqlscan.select.SelectQuery;
+import com.tdtsqlscan.web.client.ParserServiceClient;
+import com.tdtsqlscan.web.client.dto.ParseResultDto;
+import com.tdtsqlscan.web.client.dto.StatementDto;
+import com.tdtsqlscan.web.client.dto.StatementType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,24 +17,26 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.concurrent.ConcurrentHashMap;
 
 @RestController
 public class BteqUploadController {
 
     private static final Logger logger = LoggerFactory.getLogger(BteqUploadController.class);
 
-    private final BteqScriptParser bteqScriptParser;
-    private final ChainFlowGraphConverter chainFlowGraphConverter;
+    private final ParserServiceClient parserServiceClient;
     private final ObjectMapper objectMapper;
-    private final Map<String, BteqScript> parsedScripts = new ConcurrentHashMap<>();
+
+    // We need to store the parsed results for later use, e.g., for visualizing SELECTs.
+    // The key will be the script name.
+    private final Map<String, ParseResultDto> parsedScriptsCache = new HashMap<>();
 
 
     public static class GraphResponse {
@@ -61,139 +45,60 @@ public class BteqUploadController {
         public Map<String, FileMetadata> fileMetadata;
     }
 
-    public BteqUploadController() {
-        logger.info("Initializing BteqUploadController");
-        List<QueryParser> sqlParsers = new ArrayList<>();
-        sqlParsers.add(new SelectParser());
-        sqlParsers.add(new CreateTableParser());
-        sqlParsers.add(new DropTableParser());
-        sqlParsers.add(new CreateIndexParser());
-        sqlParsers.add(new InsertParser());
-        sqlParsers.add(new UpdateParser());
-        sqlParsers.add(new DeleteParser());
-        this.bteqScriptParser = new BteqScriptParser(sqlParsers);
-        this.chainFlowGraphConverter = new ChainFlowGraphConverter();
-        this.objectMapper = new ObjectMapper();
-        logger.info("BteqUploadController initialized");
+    // Helper class to hold script data along with its original name and order
+    public static class ScriptData {
+        public final String name;
+        public final long size;
+        public final String encoding;
+        public final ParseResultDto parseResult;
+
+        public ScriptData(String name, long size, String encoding, ParseResultDto parseResult) {
+            this.name = name;
+            this.size = size;
+            this.encoding = encoding;
+            this.parseResult = parseResult;
+        }
+    }
+
+
+    public BteqUploadController(ParserServiceClient parserServiceClient, ObjectMapper objectMapper) {
+        this.parserServiceClient = parserServiceClient;
+        this.objectMapper = objectMapper;
     }
 
     @PostMapping("/upload")
     public GraphResponse handleFileUpload(@RequestParam("files") MultipartFile[] files, @RequestParam("fileOrder") String fileOrderJson) throws IOException {
         logger.info("Received {} files for upload", files.length);
-        parsedScripts.clear();
+        parsedScriptsCache.clear();
 
-        List<Map<String, String>> fileOrderList = objectMapper.readValue(fileOrderJson, new TypeReference<List<Map<String, String>>>(){});
+        List<Map<String, String>> fileOrderList = objectMapper.readValue(fileOrderJson, new TypeReference<List<Map<String, String>>>() {});
         Map<String, Integer> fileOrderMap = fileOrderList.stream()
                 .collect(Collectors.toMap(map -> map.get("name"), map -> Integer.parseInt(map.get("order"))));
 
-
-        List<BteqScript> scripts = new ArrayList<>();
+        List<ScriptData> scripts = new ArrayList<>();
         for (MultipartFile file : files) {
             String content = new String(file.getBytes(), StandardCharsets.UTF_8);
-            BteqScript script = bteqScriptParser.parse(content, file.getOriginalFilename());
-            script.setSize(file.getSize());
-            script.setEncoding(StandardCharsets.UTF_8.name());
-            scripts.add(script);
-            parsedScripts.put(script.getScriptName(), script);
+            ParseResultDto parseResult = parserServiceClient.parse(content);
+            ScriptData scriptData = new ScriptData(file.getOriginalFilename(), file.getSize(), StandardCharsets.UTF_8.name(), parseResult);
+            scripts.add(scriptData);
+            parsedScriptsCache.put(scriptData.name, parseResult);
         }
 
-        // Sort scripts: primary by user order, secondary by script name
-        scripts.sort(Comparator
-                .comparing((BteqScript s) -> fileOrderMap.getOrDefault(s.getScriptName(), Integer.MAX_VALUE))
-                .thenComparing(BteqScript::getScriptName));
+        scripts.sort(Comparator.comparing(s -> fileOrderMap.getOrDefault(s.name, Integer.MAX_VALUE)));
 
-
+        ChainFlowGraphConverter chainFlowGraphConverter = new ChainFlowGraphConverter();
         Graph chainFlowGraph = chainFlowGraphConverter.convert(scripts, fileOrderList);
-        logger.info("Generated chain flow graph with {} nodes and {} edges", chainFlowGraph.getNodes().size(), chainFlowGraph.getEdges().size());
 
         Map<String, Graph> bteqFlows = new LinkedHashMap<>();
-        for (BteqScript script : scripts) {
-            // Important: Create a new converter for each script as it's stateful
+        for (ScriptData script : scripts) {
             DataFlowGraphConverter dataFlowGraphConverter = new DataFlowGraphConverter();
-            Graph bteqFlowGraph = dataFlowGraphConverter.convert(script);
-            bteqFlows.put(script.getScriptName(), bteqFlowGraph);
-            logger.info("Generated data flow graph for {} with {} nodes and {} edges",
-                    script.getScriptName(), bteqFlowGraph.getNodes().size(), bteqFlowGraph.getEdges().size());
+            Graph bteqFlowGraph = dataFlowGraphConverter.convert(script.parseResult);
+            bteqFlows.put(script.name, bteqFlowGraph);
         }
 
         Map<String, FileMetadata> fileMetadataMap = new LinkedHashMap<>();
-        for (BteqScript script : scripts) {
-            Set<String> createdTables = new HashSet<>();
-            Set<String> droppedTables = new HashSet<>();
-            Set<String> readTables = new HashSet<>();
-            Set<String> writtenTables = new HashSet<>();
-            int transactionCount = 0;
-
-            for (BteqCommand command : script.getCommands()) {
-                if (command instanceof BteqSqlCommand) {
-                    transactionCount++;
-                    try {
-                        SQLQuery query = ((BteqSqlCommand) command).getQuery();
-                        logger.info("Processing query: {}", command.getRawText());
-                        if (query == null) {
-                            logger.warn("Query object is null for command: {}", command.getRawText());
-                            continue;
-                        }
-                        logger.info("Query class: {}", query.getClass().getName());
-
-                        if (query instanceof SelectQuery) {
-                            SelectQuery selectQuery = (SelectQuery) query;
-                            for (SQLTableRef tableRef : selectQuery.getTables()) {
-                                readTables.add(SQLParserUtils.extractTableFromExpression(tableRef.getExpression()).toUpperCase());
-                            }
-                        } else if (query instanceof InsertQuery) {
-                            InsertQuery insertQuery = (InsertQuery) query;
-                            if (insertQuery.getTableName() != null) {
-                                writtenTables.add(insertQuery.getTableName().toUpperCase());
-                            } else {
-                                logger.warn("Found InsertQuery with null table name: {}", command.getRawText());
-                            }
-                            if (insertQuery.isSelect()) {
-                                for (String sourceTable : insertQuery.getSourceTables()) {
-                                    readTables.add(SQLParserUtils.extractTableFromExpression(sourceTable).toUpperCase());
-                                }
-                            }
-                        } else if (query instanceof UpdateQuery) {
-                            UpdateQuery updateQuery = (UpdateQuery) query;
-                            writtenTables.add(updateQuery.getTargetTable().toUpperCase());
-                            for (String sourceTable : updateQuery.getSourceTables()) {
-                                readTables.add(sourceTable.toUpperCase());
-                            }
-                        } else if (query instanceof DeleteQuery) {
-                            DeleteQuery deleteQuery = (DeleteQuery) query;
-                            writtenTables.add(deleteQuery.getTable().toUpperCase());
-                        } else if (query instanceof CreateTableQuery) {
-                            CreateTableQuery createTableQuery = (CreateTableQuery) query;
-                            String tableName = createTableQuery.getTableName().toUpperCase();
-                            createdTables.add(tableName);
-                            writtenTables.add(tableName);
-                        } else if (query instanceof DropTableQuery) {
-                            DropTableQuery dropTableQuery = (DropTableQuery) query;
-                            droppedTables.add(dropTableQuery.getTableName().toUpperCase());
-                        }
-                    } catch (Exception e) {
-                        logger.error("Error processing command: " + command.getRawText(), e);
-                    }
-                }
-            }
-
-            FileMetadata metadata = new FileMetadata();
-            metadata.setTransactions(transactionCount);
-
-            Set<String> finalInputTables = new HashSet<>(readTables);
-            finalInputTables.removeAll(createdTables);
-
-            Set<String> finalOutputTables = new HashSet<>(writtenTables);
-            finalOutputTables.removeAll(droppedTables);
-
-            for (String table : finalInputTables) {
-                metadata.addInputTable(table);
-            }
-            for (String table : finalOutputTables) {
-                metadata.addOutputTable(table);
-            }
-
-            fileMetadataMap.put(script.getScriptName(), metadata);
+        for (ScriptData script : scripts) {
+            fileMetadataMap.put(script.name, extractFileMetadata(script.parseResult));
         }
 
         GraphResponse response = new GraphResponse();
@@ -204,47 +109,103 @@ public class BteqUploadController {
         return response;
     }
 
-    @GetMapping("/hello")
-    public String hello() {
-        return "Hello from BTEQ Flow Visualizer!";
-    }
+    private FileMetadata extractFileMetadata(ParseResultDto parseResult) {
+        Set<String> createdTables = new HashSet<>();
+        Set<String> droppedTables = new HashSet<>();
+        Set<String> readTables = new HashSet<>();
+        Set<String> writtenTables = new HashSet<>();
+        int transactionCount = 0;
 
-    @PostMapping("/api/visualize-select")
-    public Graph visualizeSelect(@RequestParam("scriptName") String scriptName, @RequestParam("commandId") String commandId) {
-        logger.info("Request to visualize select query for script: {}, commandId: {}", scriptName, commandId);
+        for (StatementDto stmt : parseResult.getStatements()) {
+            if (stmt.getType() == StatementType.SQL_DDL || stmt.getType() == StatementType.SQL_DML) {
+                transactionCount++;
+                Map<String, String> details = stmt.getDetails();
+                if (details == null) continue;
 
-        BteqScript script = parsedScripts.get(scriptName);
-        if (script == null) {
-            logger.error("Script not found: {}", scriptName);
-            return new Graph(); // Return empty graph
-        }
-
-        try {
-            // commandId is "cmd-INDEX"
-            int commandIndex = Integer.parseInt(commandId.split("-")[1]);
-            BteqCommand command = script.getCommands().get(commandIndex);
-
-            if (command instanceof BteqSqlCommand) {
-                Object query = ((BteqSqlCommand) command).getQuery();
-                SelectQuery selectQuery = null;
-
-                if (query instanceof SelectQuery) {
-                    selectQuery = (SelectQuery) query;
-                } else if (query instanceof InsertQuery && ((InsertQuery) query).isSelect()) {
-                    selectQuery = ((InsertQuery) query).getSelectQuery();
-                } else if (query instanceof CreateTableQuery && ((CreateTableQuery) query).getSelectQuery() != null) {
-                    selectQuery = ((CreateTableQuery) query).getSelectQuery();
-                }
-
-                if (selectQuery != null) {
-                    SelectGraphConverter converter = new SelectGraphConverter();
-                    return converter.convert(selectQuery);
+                switch (stmt.getCommandName().toUpperCase()) {
+                    case "CREATE TABLE":
+                        String createdTable = details.get("table_name");
+                        if (createdTable != null) {
+                            createdTables.add(createdTable.toUpperCase());
+                            writtenTables.add(createdTable.toUpperCase());
+                        }
+                        // If CREATE TABLE AS SELECT, it also reads from tables
+                        if (details.containsKey("source_tables")) {
+                            String sourceTables = details.get("source_tables");
+                            for(String tbl : sourceTables.split(",")) {
+                                readTables.add(tbl.trim().toUpperCase());
+                            }
+                        }
+                        break;
+                    case "DROP TABLE":
+                        String droppedTable = details.get("table_name");
+                        if (droppedTable != null) {
+                            droppedTables.add(droppedTable.toUpperCase());
+                        }
+                        break;
+                    case "INSERT":
+                        String targetTable = details.get("table_name");
+                        if (targetTable != null) {
+                            writtenTables.add(targetTable.toUpperCase());
+                        }
+                        if (details.containsKey("source_tables")) {
+                            String sourceTables = details.get("source_tables");
+                             for(String tbl : sourceTables.split(",")) {
+                                readTables.add(tbl.trim().toUpperCase());
+                            }
+                        }
+                        break;
+                    case "UPDATE":
+                        String updatedTable = details.get("table_name");
+                        if(updatedTable != null) {
+                            writtenTables.add(updatedTable.toUpperCase());
+                        }
+                        if (details.containsKey("source_tables")) {
+                            String sourceTables = details.get("source_tables");
+                             for(String tbl : sourceTables.split(",")) {
+                                readTables.add(tbl.trim().toUpperCase());
+                            }
+                        }
+                        break;
+                    case "DELETE":
+                         String deletedFromTable = details.get("table_name");
+                         if(deletedFromTable != null) {
+                            writtenTables.add(deletedFromTable.toUpperCase());
+                         }
+                        break;
+                    case "SELECT":
+                         if (details.containsKey("source_tables")) {
+                            String sourceTables = details.get("source_tables");
+                             for(String tbl : sourceTables.split(",")) {
+                                readTables.add(tbl.trim().toUpperCase());
+                            }
+                        }
+                        break;
                 }
             }
-        } catch (Exception e) {
-            logger.error("Error generating select visualization for script: {}, commandId: {}", scriptName, commandId, e);
         }
 
-        return new Graph(); // Return empty graph on error
+        FileMetadata metadata = new FileMetadata();
+        metadata.setTransactions(transactionCount);
+
+        Set<String> finalInputTables = new HashSet<>(readTables);
+        finalInputTables.removeAll(createdTables);
+
+        Set<String> finalOutputTables = new HashSet<>(writtenTables);
+        finalOutputTables.removeAll(droppedTables);
+
+        finalInputTables.forEach(metadata::addInputTable);
+        finalOutputTables.forEach(metadata::addOutputTable);
+
+        return metadata;
+    }
+
+    // This endpoint is now broken because it relies on BteqScript and specific command indexing.
+    // It will need to be refactored or removed. For now, it will return an empty graph.
+    // TODO: Refactor visualize-select to work with ParseResultDto
+    @PostMapping("/api/visualize-select")
+    public Graph visualizeSelect(@RequestParam("scriptName") String scriptName, @RequestParam("commandId") String commandId) {
+        logger.warn("The visualize-select endpoint is temporarily disabled pending refactoring.");
+        return new Graph();
     }
 }

--- a/app-web/src/main/java/com/tdtsqlscan/web/ChainFlowGraphConverter.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/ChainFlowGraphConverter.java
@@ -1,9 +1,9 @@
 package com.tdtsqlscan.web;
 
-import com.tdtsqlscan.etl.BteqScript;
 import com.tdtsqlscan.graph.Graph;
 import com.tdtsqlscan.graph.Node;
 import com.tdtsqlscan.graph.Edge;
+import com.tdtsqlscan.web.BteqUploadController.ScriptData; // Assuming ScriptData is accessible
 
 import java.util.List;
 import java.util.Map;
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 
 public class ChainFlowGraphConverter {
 
-    public Graph convert(List<BteqScript> scripts, List<Map<String, String>> fileOrder) {
+    public Graph convert(List<ScriptData> scripts, List<Map<String, String>> fileOrder) {
         Graph graph = new Graph();
         Map<String, Integer> orderByName = fileOrder.stream()
                 .collect(Collectors.toMap(
@@ -20,11 +20,11 @@ public class ChainFlowGraphConverter {
                         map -> Integer.parseInt(map.get("order"))
                 ));
 
-        Map<String, BteqScript> scriptsByName = scripts.stream()
-                .collect(Collectors.toMap(BteqScript::getScriptName, script -> script));
+        Map<String, ScriptData> scriptsByName = scripts.stream()
+                .collect(Collectors.toMap(script -> script.name, script -> script));
 
-        Map<Integer, List<BteqScript>> scriptsByOrder = scripts.stream()
-                .collect(Collectors.groupingBy(script -> orderByName.get(script.getScriptName())));
+        Map<Integer, List<ScriptData>> scriptsByOrder = scripts.stream()
+                .collect(Collectors.groupingBy(script -> orderByName.get(script.name)));
 
         int y_gap = 150;
         int max_y_offset = 0;
@@ -39,8 +39,8 @@ public class ChainFlowGraphConverter {
                             int yOffset = (scriptCount > 1) ? (scriptCount - 1) * y_gap / 2 : 0;
 
                             for (int i = 0; i < scriptCount; i++) {
-                                BteqScript script = entry.getValue().get(i);
-                                Node node = new Node(script.getScriptName(), script.getScriptName());
+                                ScriptData script = entry.getValue().get(i);
+                                Node node = new Node(script.name, script.name);
                                 int x = entry.getKey() * 400;
                                 int y = (i * y_gap) - yOffset + max_y_offset;
                                 node.getProperties().put("x", String.valueOf(x));
@@ -49,17 +49,14 @@ public class ChainFlowGraphConverter {
                                 node.getProperties().put("image", "/images/bteq_script.png");
                                 node.getProperties().put("size", "50");
 
-                                BteqScript originalScript = scriptsByName.get(script.getScriptName());
+                                ScriptData originalScript = scriptsByName.get(script.name);
                                 if (originalScript != null) {
-                                    node.getProperties().put("fileName", originalScript.getScriptName());
-                                    node.getProperties().put("fileSize", String.valueOf(originalScript.getSize()));
-                                    node.getProperties().put("fileEncoding", originalScript.getEncoding());
+                                    node.getProperties().put("fileName", originalScript.name);
+                                    node.getProperties().put("fileSize", String.valueOf(originalScript.size));
+                                    node.getProperties().put("fileEncoding", originalScript.encoding);
                                 }
                                 nodes.add(node);
                                 graph.addNode(node);
-                            }
-                            if (scriptCount > 1) {
-                               // max_y_offset += (scriptCount -1) * y_gap;
                             }
                             return nodes;
                         }
@@ -75,7 +72,6 @@ public class ChainFlowGraphConverter {
 
             for (Node fromNode : currentNodes) {
                 for (Node toNode : nextNodes) {
-                    // Create an arrow node
                     String arrowId = "arrow-" + UUID.randomUUID().toString();
                     Node arrowNode = new Node(arrowId, "");
                     int fromX = Integer.parseInt((String) fromNode.getProperties().get("x"));

--- a/app-web/src/main/java/com/tdtsqlscan/web/DataFlowGraphConverter.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/DataFlowGraphConverter.java
@@ -1,22 +1,19 @@
 package com.tdtsqlscan.web;
 
-import com.tdtsqlscan.core.SQLJoin;
-import com.tdtsqlscan.core.SQLTableRef;
-import com.tdtsqlscan.ddl.ColumnDefinition;
-import com.tdtsqlscan.ddl.CreateIndexQuery;
-import com.tdtsqlscan.ddl.CreateTableQuery;
-import com.tdtsqlscan.ddl.DropTableQuery;
-import com.tdtsqlscan.dml.DeleteQuery;
-import com.tdtsqlscan.dml.InsertQuery;
-import com.tdtsqlscan.dml.UpdateQuery;
-import com.tdtsqlscan.etl.*;
 import com.tdtsqlscan.graph.Edge;
 import com.tdtsqlscan.graph.Graph;
 import com.tdtsqlscan.graph.Node;
-import com.tdtsqlscan.select.SelectQuery;
+import com.tdtsqlscan.web.client.dto.ParseResultDto;
+import com.tdtsqlscan.web.client.dto.StatementDto;
+import com.tdtsqlscan.web.client.dto.StatementType;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ArrayList;
 
 
 public class DataFlowGraphConverter {
@@ -26,13 +23,10 @@ public class DataFlowGraphConverter {
     private static final int LANE_HEIGHT = 120;
     private static final int X_OFFSET_STEP_SQL = 180;
     private static final int X_OFFSET_STEP_CONTROL = 75;
-    private static final int X_OFFSET_STEP_LANE_CHANGE = 50;
 
     private Graph graph;
-    private Map<String, Node> tableNodes;
     private LaneManager laneManager;
     private int xOffset;
-    private String currentDatabase = null;
 
     private static class LaneManager {
         private final Map<String, Integer> tableToLane = new HashMap<>();
@@ -41,99 +35,30 @@ public class DataFlowGraphConverter {
 
         int getLaneForTable(String tableName) {
             if (tableName == null) {
-                // For commands without a table, create a new lane but don't track the table
                 int lane = nextLane++;
                 usedLanes.add(lane);
                 return lane;
             }
-
-            if (tableToLane.containsKey(tableName)) {
-                return tableToLane.get(tableName);
-            }
-
-            int lane = nextLane++;
-            tableToLane.put(tableName, lane);
-            usedLanes.add(lane);
-            return lane;
+            return tableToLane.computeIfAbsent(tableName.toUpperCase(), k -> {
+                int lane = nextLane++;
+                usedLanes.add(lane);
+                return lane;
+            });
         }
     }
 
-    public Graph convert(BteqScript script) {
+    public Graph convert(ParseResultDto parseResult) {
         this.graph = new Graph();
-        this.tableNodes = new HashMap<>();
         this.laneManager = new LaneManager();
         this.xOffset = 0;
         Node lastCommandNode = null;
 
-        // Pre-calculate lane numbers for all commands to detect lane changes
-        Map<BteqCommand, Integer> commandToLane = new HashMap<>();
-        LaneManager laneNumberer = new LaneManager();
-        for (BteqCommand command : script.getCommands()) {
-            commandToLane.put(command, getLaneNumber(command, laneNumberer));
+        List<StatementDto> statements = parseResult.getStatements();
+        for (int i = 0; i < statements.size(); i++) {
+            StatementDto stmt = statements.get(i);
+            lastCommandNode = processStatement(stmt, i, lastCommandNode);
         }
 
-        int i = 0;
-        while (i < script.getCommands().size()) {
-            BteqCommand command = script.getCommands().get(i);
-
-            if (command instanceof BteqControlCommand && ((BteqControlCommand) command).getType() == BteqCommandType.DATABASE) {
-                String[] parts = command.getRawText().trim().split("\\s+");
-                if (parts.length > 1) {
-                    String dbName = parts[1];
-                    if (dbName.endsWith(";")) {
-                        dbName = dbName.substring(0, dbName.length() - 1);
-                    }
-                    this.currentDatabase = dbName;
-                }
-            }
-            int xStep;
-
-            // Check if the command is a candidate for grouping
-            if (isGroupableInsert(command)) {
-                List<BteqCommand> group = findInsertGroup(script.getCommands(), i);
-                lastCommandNode = processInsertGroup(group, i, lastCommandNode);
-
-                int groupSize = group.size();
-                int currentLane = commandToLane.get(command);
-                int nextLane = -2; // Use a value that is different from any possible lane number
-                if (i + groupSize < script.getCommands().size()) {
-                    nextLane = commandToLane.get(script.getCommands().get(i + groupSize));
-                }
-
-                if (nextLane != -2 && currentLane != nextLane) {
-                    xStep = X_OFFSET_STEP_LANE_CHANGE;
-                } else {
-                    xStep = X_OFFSET_STEP_SQL;
-                }
-                i += groupSize; // Skip past the commands that were just grouped
-            } else {
-                int currentLane = commandToLane.get(command);
-                int nextLane = -2;
-                if (i + 1 < script.getCommands().size()) {
-                    nextLane = commandToLane.get(script.getCommands().get(i + 1));
-                }
-
-                if (nextLane != -2 && currentLane != nextLane) {
-                    xStep = X_OFFSET_STEP_LANE_CHANGE;
-                } else {
-                    if (command instanceof BteqSqlCommand) {
-                        int lineCount = command.getRawText().split("\r\n|\r|\n").length;
-                        // Use a larger step for multi-line SQL to avoid overlap
-                        xStep = lineCount > 3 ? X_OFFSET_STEP_SQL * 2 : X_OFFSET_STEP_SQL;
-                    } else if (command instanceof BteqControlCommand && ((BteqControlCommand) command).getType() == BteqCommandType.EXIT) {
-                        xStep = X_OFFSET_STEP_SQL;
-                    } else {
-                        // For other non-SQL commands, use the control step
-                        xStep = X_OFFSET_STEP_CONTROL;
-                    }
-                }
-                lastCommandNode = processCommand(command, i, lastCommandNode, xStep);
-                i++;
-            }
-            xOffset += xStep;
-        }
-
-        // After processing all commands, populate the guide line coordinates
         graph.getHorizontalLaneYs().add(BTEQ_LANE_Y + (DATA_LANE_START_Y - BTEQ_LANE_Y) / 2);
         for (int lane : laneManager.usedLanes) {
             graph.getHorizontalLaneYs().add(DATA_LANE_START_Y + (lane * LANE_HEIGHT) + (LANE_HEIGHT / 2));
@@ -142,35 +67,25 @@ public class DataFlowGraphConverter {
         return graph;
     }
 
-    private Node processCommand(BteqCommand command, int index, Node lastCommandNode, int xStep) {
+    private Node processStatement(StatementDto stmt, int index, Node lastCommandNode) {
         String commandNodeId = "cmd-" + index;
         int yPos;
-        int currentX = xOffset;
+        int xStep = X_OFFSET_STEP_CONTROL;
 
-        if (command instanceof BteqControlCommand || command instanceof BteqConfigurationCommand ||
-            (command instanceof BteqSqlCommand && ((BteqSqlCommand) command).getQuery() instanceof SelectQuery)) {
+        if (stmt.getType() == StatementType.BTEQ_COMMAND || "SELECT".equalsIgnoreCase(stmt.getCommandName())) {
             yPos = BTEQ_LANE_Y;
-            if (command instanceof BteqControlCommand && ((BteqControlCommand) command).getType() == BteqCommandType.LABEL) {
-                graph.getVerticalLabelXs().add(currentX);
+            if (".LABEL".equalsIgnoreCase(stmt.getCommandName())) {
+                graph.getVerticalLabelXs().add(xOffset);
             }
         } else {
-            // For SQL commands, the lane is determined by the TARGET table.
-            String targetTable = getTargetTable(command);
+            xStep = X_OFFSET_STEP_SQL;
+            String targetTable = getTargetTable(stmt);
             int lane = laneManager.getLaneForTable(targetTable);
             yPos = DATA_LANE_START_Y + (lane * LANE_HEIGHT);
         }
 
-        Node commandNode = createCommandNode(command, commandNodeId);
-
-        if (command instanceof BteqSqlCommand) {
-            // For SQL commands, center them between potential source/target tables
-            commandNode.addProperty("x", currentX + xStep / 2);
-            handleDataFlow(commandNode, (BteqSqlCommand) command, yPos, currentX);
-        } else {
-            // For non-SQL commands, place them at the start of the block
-            commandNode.addProperty("x", currentX);
-        }
-
+        Node commandNode = createCommandNode(stmt, commandNodeId);
+        commandNode.addProperty("x", xOffset + xStep / 2);
         commandNode.addProperty("y", yPos);
         graph.addNode(commandNode);
 
@@ -181,219 +96,92 @@ public class DataFlowGraphConverter {
             graph.addEdge(logicEdge);
         }
 
+        xOffset += xStep;
         return commandNode;
     }
 
-    private int getLaneNumber(BteqCommand command, LaneManager laneManager) {
-        if (command instanceof BteqControlCommand || command instanceof BteqConfigurationCommand ||
-                (command instanceof BteqSqlCommand && ((BteqSqlCommand) command).getQuery() instanceof SelectQuery)) {
-            return -1; // Special value for the BTEQ lane
-        } else {
-            String targetTable = getTargetTable(command);
-            return laneManager.getLaneForTable(targetTable);
+    private String getTargetTable(StatementDto stmt) {
+        if (stmt.getDetails() != null && stmt.getDetails().containsKey("table_name")) {
+            return stmt.getDetails().get("table_name");
         }
+        return null;
     }
 
-    private String getTargetTable(BteqCommand command) {
-        String tableName = null;
-        if (command instanceof BteqSqlCommand) {
-            Object query = ((BteqSqlCommand) command).getQuery();
-            if (query instanceof CreateTableQuery) tableName = ((CreateTableQuery) query).getTableName();
-            else if (query instanceof InsertQuery) tableName = ((InsertQuery) query).getTableName();
-            else if (query instanceof UpdateQuery) tableName = ((UpdateQuery) query).getTargetTable();
-            else if (query instanceof DropTableQuery) tableName = ((DropTableQuery) query).getTableName();
-            else if (query instanceof DeleteQuery) tableName = ((DeleteQuery) query).getTable();
-        }
-        return tableName != null ? tableName.toUpperCase() : null;
-    }
-
-    private boolean isGroupableInsert(BteqCommand command) {
-        if (!(command instanceof BteqSqlCommand)) {
-            return false;
-        }
-        Object query = ((BteqSqlCommand) command).getQuery();
-        if (!(query instanceof InsertQuery)) {
-            return false;
-        }
-        // Groupable inserts are those that are not INSERT...SELECT
-        return !((InsertQuery) query).isSelect();
-    }
-
-    private Node processInsertGroup(List<BteqCommand> group, int startIndex, Node lastCommandNode) {
-        BteqCommand firstCommand = group.get(0);
-        String targetTable = ((InsertQuery) ((BteqSqlCommand) firstCommand).getQuery()).getTableName().toUpperCase();
-        String commandNodeId = "cmd-group-" + startIndex;
-
-        // Build the consolidated node
-        StringBuilder fullText = new StringBuilder();
-        for (BteqCommand cmd : group) {
-            fullText.append(cmd.getRawText()).append("\n\n");
-        }
-        String label = String.format("Batch INSERT (%d)", group.size());
-        Node commandNode = new Node(commandNodeId, label);
-        commandNode.addProperty("shape", "image");
-        commandNode.addProperty("image", "images/insert.png");
-        commandNode.addProperty("size", 30);
-        commandNode.addProperty("fullText", fullText.toString().trim());
-        commandNode.addProperty("fixed", true);
-
-        // Position and connect the node
-        int lane = laneManager.getLaneForTable(targetTable);
-        int yPos = DATA_LANE_START_Y + (lane * LANE_HEIGHT);
-        int currentX = xOffset;
-
-        commandNode.addProperty("x", currentX + X_OFFSET_STEP_SQL / 2);
-        commandNode.addProperty("y", yPos);
-        graph.addNode(commandNode);
-
-        // Keep this call to register the table for lane management, but don't create an edge
-        getOrCreateTableNode(targetTable, yPos);
-
-        // Connect the logic flow
-        if (lastCommandNode != null) {
-            Edge logicEdge = new Edge(lastCommandNode.getId(), commandNode.getId(), "");
-            logicEdge.addProperty("dashes", true);
-            logicEdge.addProperty("arrows", "to");
-            graph.addEdge(logicEdge);
-        }
-
-        return commandNode;
-    }
-
-    private List<BteqCommand> findInsertGroup(List<BteqCommand> commands, int startIndex) {
-        List<BteqCommand> group = new ArrayList<>();
-        BteqCommand firstCommand = commands.get(startIndex);
-        String targetTable = ((InsertQuery) ((BteqSqlCommand) firstCommand).getQuery()).getTableName();
-        group.add(firstCommand);
-
-        for (int i = startIndex + 1; i < commands.size(); i++) {
-            BteqCommand nextCommand = commands.get(i);
-            if (isGroupableInsert(nextCommand)) {
-                String nextTargetTable = ((InsertQuery) ((BteqSqlCommand) nextCommand).getQuery()).getTableName();
-                if (targetTable.equals(nextTargetTable)) {
-                    group.add(nextCommand);
-                } else {
-                    break; // Different table, end of group
-                }
-            } else {
-                break; // Not a groupable insert, end of group
-            }
-        }
-        return group;
-    }
-
-    private Set<String> getRelatedTables(BteqCommand command) {
-        Set<String> tables = new HashSet<>();
-        if (command instanceof BteqSqlCommand) {
-            Object query = ((BteqSqlCommand) command).getQuery();
-            if (query instanceof CreateTableQuery) {
-                tables.add(((CreateTableQuery) query).getTableName());
-            } else if (query instanceof InsertQuery) {
-                tables.add(((InsertQuery) query).getTableName());
-                if (((InsertQuery) query).isSelect()) {
-                    tables.addAll(((InsertQuery) query).getSourceTables());
-                }
-            } else if (query instanceof UpdateQuery) {
-                tables.add(((UpdateQuery) query).getTargetTable());
-            } else if (query instanceof DropTableQuery) {
-                tables.add(((DropTableQuery) query).getTableName());
-            }
-        }
-        return tables;
-    }
-
-    private Node createCommandNode(BteqCommand command, String id) {
-        String label = "UNKNOWN";
+    private Node createCommandNode(StatementDto stmt, String id) {
+        String label = stmt.getCommandName();
         String shape = "box";
         String image = null;
 
-        if (command instanceof BteqConfigurationCommand) {
-            label = "START";
-            shape = "image";
-            image = "images/bteq_commands/start.png";
-        } else if (command instanceof BteqControlCommand) {
-            BteqControlCommand controlCommand = (BteqControlCommand) command;
-            BteqCommandType type = controlCommand.getType();
-
-            if (type == BteqCommandType.SET || type == BteqCommandType.DECLARE) {
-                shape = "image";
-                image = "images/bteq_commands/config.png";
-                label = ""; // The icon is the representation
-            } else if (type == BteqCommandType.EXPORT) {
-                shape = "image";
-                image = "images/bteq_commands/export.png";
-                label = "";
-            } else if (type == BteqCommandType.LABEL) {
-                shape = "image";
-                image = "images/bteq_commands/label.png";
-                String rawText = controlCommand.getRawText().trim();
-                String[] parts = rawText.split("\\s+");
-                if (parts.length > 1) {
-                    label = parts[1];
-                    if (label.endsWith(";")) {
-                        label = label.substring(0, label.length() - 1);
-                    }
-                } else {
+        if (stmt.getType() == StatementType.BTEQ_COMMAND) {
+            shape = "ellipse";
+            // Map BTEQ command names to images
+            switch (label.toUpperCase()) {
+                case ".LOGON":
+                case ".DATABASE":
+                    label = "START";
+                    shape = "image";
+                    image = "/images/bteq_commands/start.png";
+                    break;
+                case ".SET":
+                case ".DECLARE":
+                    shape = "image";
+                    image = "/images/bteq_commands/config.png";
                     label = "";
-                }
-            } else if (type == BteqCommandType.GOTO) {
-                shape = "image";
-                image = "images/bteq_commands/goto.png";
-                label = "";
-            } else if (type == BteqCommandType.IF) {
-                shape = "image";
-                image = "images/bteq_commands/if.png";
-                label = "";
-            } else if (type == BteqCommandType.OTHER) {
-                String rawText = controlCommand.getRawText().trim();
-                if (rawText.startsWith(".")) {
-                    label = rawText.split("\\s+")[0];
-                } else {
-                    label = ".OTHER";
-                }
-                shape = "ellipse";
-            } else {
-                label = "." + type.toString();
-                shape = "ellipse";
+                    break;
+                case ".EXPORT":
+                    shape = "image";
+                    image = "/images/bteq_commands/export.png";
+                    label = "";
+                    break;
+                case ".LABEL":
+                    shape = "image";
+                    image = "/images/bteq_commands/label.png";
+                    label = stmt.getDetails() != null ? stmt.getDetails().getOrDefault("label_name", "") : "";
+                    break;
+                case ".GOTO":
+                    shape = "image";
+                    image = "/images/bteq_commands/goto.png";
+                    label = "";
+                    break;
+                case ".IF":
+                    shape = "image";
+                    image = "/images/bteq_commands/if.png";
+                    label = "";
+                    break;
+                case ".EXIT":
+                case ".LOGOFF":
+                    shape = "star";
+                    break;
             }
-
-            if (type == BteqCommandType.EXIT) {
-                shape = "star";
-            }
-        } else if (command instanceof BteqSqlCommand) {
-            Object query = ((BteqSqlCommand) command).getQuery();
-            shape = "image"; // Default to image for SQL commands
-
-            if (query instanceof CreateTableQuery) {
-                CreateTableQuery createTableQuery = (CreateTableQuery) query;
-                if (createTableQuery.isVolatile()) {
-                    label = "CREATE VOLATILE TABLE";
-                    image = "images/create_volatile_table.png";
-                } else {
-                    label = "CREATE TABLE";
-                    image = "images/create_table.png";
-                }
-            } else if (query instanceof InsertQuery) {
-                label = "INSERT";
-                image = "images/insert.png";
-            } else if (query instanceof SelectQuery) {
-                label = "SELECT";
-                image = "images/select.png";
-            } else if (query instanceof UpdateQuery) {
-                label = "UPDATE";
-                image = "images/update.png";
-            } else if (query instanceof DropTableQuery) {
-                label = "DROP TABLE";
-                image = "images/drop_table.png";
-            } else if (query instanceof DeleteQuery) {
-                label = "DELETE";
-                image = "images/delete.png";
-            } else if (query instanceof CreateIndexQuery) {
-                label = "CREATE INDEX";
-                image = "images/right_arrow.png";
-            } else {
-                label = "SQL";
-                shape = "box"; // Revert to box for other SQL
+        } else { // SQL Statements
+            shape = "image";
+            switch (label.toUpperCase()) {
+                case "CREATE TABLE":
+                     image = stmt.getDetails() != null && "true".equalsIgnoreCase(stmt.getDetails().get("is_volatile"))
+                            ? "/images/create_volatile_table.png"
+                            : "/images/create_table.png";
+                    break;
+                case "INSERT":
+                    image = "/images/insert.png";
+                    break;
+                case "SELECT":
+                    image = "/images/select.png";
+                    break;
+                case "UPDATE":
+                    image = "/images/update.png";
+                    break;
+                case "DROP TABLE":
+                    image = "/images/drop_table.png";
+                    break;
+                case "DELETE":
+                    image = "/images/delete.png";
+                    break;
+                case "CREATE INDEX":
+                    image = "/images/right_arrow.png"; // Placeholder, might need a better icon
+                    break;
+                default:
+                    shape = "box"; // Fallback for unknown SQL
+                    break;
             }
         }
 
@@ -403,117 +191,19 @@ public class DataFlowGraphConverter {
             node.addProperty("image", image);
             node.addProperty("size", 30);
         }
-        node.addProperty("fullText", command.getRawText());
+        node.addProperty("fullText", stmt.getRawContent());
         node.addProperty("fixed", true);
-        if (command instanceof BteqConfigurationCommand) {
-            node.addProperty("noContextMenu", true);
+
+        if (stmt.getDetails() != null && !stmt.getDetails().isEmpty()) {
+            node.addProperty("metadata", new LinkedHashMap<>(stmt.getDetails()));
         }
 
-        if (command instanceof BteqSqlCommand) {
-            Object query = ((BteqSqlCommand) command).getQuery();
-            Map<String, Object> metadata = extractSqlMetadata(query);
-            if (!metadata.isEmpty()) {
-                node.addProperty("metadata", metadata);
-            }
-
-            // Check if the query contains a SELECT statement that can be visualized
-            if (query instanceof SelectQuery ||
-                (query instanceof InsertQuery && ((InsertQuery) query).isSelect()) ||
-                (query instanceof CreateTableQuery && ((CreateTableQuery) query).getSelectQuery() != null)) {
-                node.addProperty("hasSelectQuery", true);
-            }
+        // Simplified check for SELECT visualization
+        if (stmt.getType() != StatementType.BTEQ_COMMAND && stmt.getDetails() != null && stmt.getDetails().containsKey("source_tables")) {
+             node.addProperty("hasSelectQuery", true);
         }
+
 
         return node;
-    }
-
-    private void handleDataFlow(Node commandNode, BteqSqlCommand sqlCommand, int yPos, int currentX) {
-        // This method is now obsolete, as per the user's request to not show data flow arrows
-        // or table nodes, only the command nodes on the correct lanes.
-    }
-
-    private Map<String, Object> extractSqlMetadata(Object query) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-
-        if (query instanceof CreateTableQuery) {
-            CreateTableQuery q = (CreateTableQuery) query;
-            metadata.put("Tipo de Tabla", q.isVolatile() ? "Volatile" : "Permanente");
-            metadata.put("Tabla Creada", q.getTableName());
-            if (q.getSourceTables() != null && !q.getSourceTables().isEmpty()) {
-                metadata.put("Tablas Origen (CTAS)", q.getSourceTables());
-            }
-            if (q.getColumns() != null && !q.getColumns().isEmpty()) {
-                List<String> columnNames = q.getColumns().stream()
-                        .map(ColumnDefinition::getName)
-                        .collect(Collectors.toList());
-                metadata.put("Columnas", columnNames);
-            }
-        } else if (query instanceof InsertQuery) {
-            InsertQuery q = (InsertQuery) query;
-            metadata.put("Tabla Destino", q.getTableName());
-            if (q.isSelect()) {
-                metadata.put("Tablas Origen", q.getSourceTables());
-            }
-            if (q.getColumns() != null && !q.getColumns().isEmpty()) {
-                metadata.put("Columnas Afectadas", q.getColumns());
-            }
-        } else if (query instanceof UpdateQuery) {
-            UpdateQuery q = (UpdateQuery) query;
-            metadata.put("Tabla Modificada", q.getTargetTable());
-            if (q.getSourceTables() != null && !q.getSourceTables().isEmpty()) {
-                metadata.put("Tablas Origen", q.getSourceTables());
-            }
-        } else if (query instanceof DeleteQuery) {
-            DeleteQuery q = (DeleteQuery) query;
-            metadata.put("Tabla Afectada", q.getTable());
-        } else if (query instanceof DropTableQuery) {
-            DropTableQuery q = (DropTableQuery) query;
-            metadata.put("Tabla Eliminada", q.getTableName());
-        } else if (query instanceof SelectQuery) {
-            SelectQuery q = (SelectQuery) query;
-            if (q.getColumns() != null && !q.getColumns().isEmpty()) {
-                metadata.put("Columnas", q.getColumns());
-            }
-            if (q.getTables() != null && !q.getTables().isEmpty()) {
-                // NOTE: This is a naive way to get the table name, but SQLTableRef does not provide a direct getter.
-                // This will work for simple cases like "TABLE as ALIAS" or "TABLE".
-                List<String> tableNames = q.getTables().stream()
-                        .map(s -> s.getExpression().split("\\s+")[0])
-                        .collect(Collectors.toList());
-                metadata.put("Tablas", tableNames);
-            }
-            if (q.getJoins() != null && !q.getJoins().isEmpty()) {
-                List<String> joinConditions = q.getJoins().stream()
-                        .map(SQLJoin::getCondition)
-                        .collect(Collectors.toList());
-                metadata.put("Joins", joinConditions);
-            }
-        } else if (query instanceof CreateIndexQuery) {
-            CreateIndexQuery q = (CreateIndexQuery) query;
-            metadata.put("Nombre del Índice", q.getIndexName());
-            metadata.put("Tabla", q.getTableName());
-            metadata.put("Tipo", q.isUnique() ? "Unique" : "No Unique");
-            if (q.getColumns() != null && !q.getColumns().isEmpty()) {
-                metadata.put("Columnas", q.getColumns());
-            }
-        }
-
-        return metadata;
-    }
-
-    private Node getOrCreateTableNode(String tableName, int yPos) {
-        String upperCaseTableName = tableName.toUpperCase();
-        Node tableNode = tableNodes.get(upperCaseTableName);
-        if (tableNode == null) {
-            // Use the original case-preserved name for the node's ID and label for display
-            tableNode = new Node(tableName, tableName);
-            tableNode.addProperty("shape", "database");
-            tableNode.addProperty("y", yPos);
-            tableNode.addProperty("fixed", true);
-            // Use the uppercase name for the map key to ensure case-insensitivity
-            tableNodes.put(upperCaseTableName, tableNode);
-            // DO NOT add the node to the graph.
-        }
-        return tableNode;
     }
 }

--- a/app-web/src/main/java/com/tdtsqlscan/web/client/ParserServiceClient.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/client/ParserServiceClient.java
@@ -1,0 +1,52 @@
+package com.tdtsqlscan.web.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tdtsqlscan.web.client.dto.ParseResultDto;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+public class ParserServiceClient {
+
+    private final CloseableHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final String parserServiceUrl;
+    // TODO: Replace with dynamic token from User Service
+    private final String apiToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXJ2aWNlLWFjY291bnQtcGFyc2VyLXNlcnZpY2UiLCJleHAiOjE3MzIwNTQ0MDB9.7sC5n9F3b_D6y_5c_G3e_X9f_2b_Z6d_Y9c_V8e_R0a";
+
+    public ParserServiceClient(ObjectMapper objectMapper, @Value("${client.parser-service.url}") String parserServiceUrl) {
+        this.httpClient = HttpClients.createDefault();
+        this.objectMapper = objectMapper;
+        this.parserServiceUrl = parserServiceUrl;
+    }
+
+    public ParseResultDto parse(String scriptContent) throws IOException {
+        String url = parserServiceUrl + "/api/v1/parse/poc";
+        HttpPost httpPost = new HttpPost(url);
+
+        httpPost.setHeader("Authorization", "Bearer " + apiToken);
+        httpPost.setHeader("Content-Type", "application/json");
+
+        Map<String, String> requestBody = Map.of("script_content", scriptContent);
+        String jsonRequestBody = objectMapper.writeValueAsString(requestBody);
+        httpPost.setEntity(new StringEntity(jsonRequestBody));
+
+        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                throw new IOException("Failed to call parser service. Status code: " + statusCode);
+            }
+            String jsonResponse = EntityUtils.toString(response.getEntity());
+            return objectMapper.readValue(jsonResponse, ParseResultDto.class);
+        }
+    }
+}

--- a/app-web/src/main/java/com/tdtsqlscan/web/client/dto/ParseResultDto.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/client/dto/ParseResultDto.java
@@ -1,0 +1,27 @@
+package com.tdtsqlscan.web.client.dto;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class ParseResultDto {
+
+    private List<StatementDto> statements;
+
+    public ParseResultDto() {
+        this.statements = new ArrayList<>();
+    }
+
+    // Getters and Setters
+
+    public List<StatementDto> getStatements() {
+        return statements;
+    }
+
+    public void setStatements(List<StatementDto> statements) {
+        this.statements = statements;
+    }
+
+    public void addStatement(StatementDto statement) {
+        this.statements.add(statement);
+    }
+}

--- a/app-web/src/main/java/com/tdtsqlscan/web/client/dto/StatementDto.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/client/dto/StatementDto.java
@@ -1,0 +1,45 @@
+package com.tdtsqlscan.web.client.dto;
+
+import java.util.Map;
+
+public class StatementDto {
+
+    private StatementType type;
+    private String commandName;
+    private String rawContent;
+    private Map<String, String> details;
+
+    // Getters and Setters
+
+    public StatementType getType() {
+        return type;
+    }
+
+    public void setType(StatementType type) {
+        this.type = type;
+    }
+
+    public String getCommandName() {
+        return commandName;
+    }
+
+    public void setCommandName(String commandName) {
+        this.commandName = commandName;
+    }
+
+    public String getRawContent() {
+        return rawContent;
+    }
+
+    public void setRawContent(String rawContent) {
+        this.rawContent = rawContent;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
+    }
+}

--- a/app-web/src/main/java/com/tdtsqlscan/web/client/dto/StatementType.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/client/dto/StatementType.java
@@ -1,0 +1,7 @@
+package com.tdtsqlscan.web.client.dto;
+
+public enum StatementType {
+    BTEQ_COMMAND,
+    SQL_DML,
+    SQL_DDL
+}

--- a/app-web/src/main/resources/application.properties
+++ b/app-web/src/main/resources/application.properties
@@ -36,3 +36,8 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 
 # TinyMCE Configuration
 tinymce.api.key=${TINYMCE_API_KEY:no-api-key}
+
+# ===============================================================
+# = CLIENT CONFIGURATION
+# ===============================================================
+client.parser-service.url=http://parser-service:8080


### PR DESCRIPTION
Este commit refactoriza BteqUploadController para que deje de usar el BteqScriptParser interno y en su lugar consuma el nuevo microservicio de parsing a través de una API REST.

Cambios clave:
- Se añade un ParserServiceClient para gestionar la comunicación HTTP con el parser-service.
- Se replican los DTOs del servicio (ParseResultDto, StatementDto) en el módulo app-web.
- Se inyecta el nuevo cliente en BteqUploadController y se reemplazan las llamadas al parser local por llamadas a la API.
- Se adaptan los convertidores de grafos (ChainFlowGraphConverter, DataFlowGraphConverter) y la lógica de metadatos para que funcionen con la nueva estructura de datos (ParseResultDto).
- El endpoint /api/visualize-select ha sido deshabilitado temporalmente y marcado con un TODO para ser refactorizado en una tarea posterior, ya que su adaptación requería cambios más profundos en el servicio de parsing.

Este es un paso crucial en la migración a microservicios siguiendo el patrón Strangler Fig.