### PR TITLE
feat: Create Spring profile to disable security in development

### DIFF
--- a/parser-service/src/main/java/com/tdtsqlscan/parser/config/DevUnsecuredSecurityConfig.java
+++ b/parser-service/src/main/java/com/tdtsqlscan/parser/config/DevUnsecuredSecurityConfig.java
@@ -3,26 +3,22 @@ package com.tdtsqlscan.parser.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
-@Profile("!dev-unsecured")
-public class SecurityConfig {
+@Profile("dev-unsecured")
+public class DevUnsecuredSecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorizeRequests ->
-                        authorizeRequests
-                                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
-                                .requestMatchers("/api/v1/**").hasAuthority("SCOPE_parser:parse")
-                                .anyRequest().denyAll()
+                        authorizeRequests.anyRequest().permitAll()
                 )
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+                .csrf(csrf -> csrf.disable());
         return http.build();
     }
 }

--- a/parser-service/src/main/resources/application-dev-unsecured.properties
+++ b/parser-service/src/main/resources/application-dev-unsecured.properties
@@ -1,0 +1,3 @@
+# This file is intentionally left blank.
+# The 'dev-unsecured' profile is activated by the presence of this file.
+# The security configuration is handled by DevUnsecuredSecurityConfig.java.


### PR DESCRIPTION
This commit introduces a new Spring profile 'dev-unsecured' to the parser-service.

When this profile is active, security is disabled, allowing for easier testing and development without the need for a valid JWT.

This is achieved by:
- Creating a new `DevUnsecuredSecurityConfig` class that is active only when the 'dev-unsecured' profile is active. This configuration permits all requests.
- Modifying the existing `SecurityConfig` to be active only when the 'dev-unsecured' profile is not active.
- Adding an `application-dev-unsecured.properties` file to easily activate the profile.