### PR TITLE
feat: Set up config-server and initial configuration repository

### DIFF
--- a/app-web/src/main/java/com/tdtsqlscan/web/client/ParserServiceClient.java
+++ b/app-web/src/main/java/com/tdtsqlscan/web/client/ParserServiceClient.java
@@ -2,12 +2,11 @@ package com.tdtsqlscan.web.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tdtsqlscan.web.client.dto.ParseResultDto;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -40,13 +39,13 @@ public class ParserServiceClient {
         String jsonRequestBody = objectMapper.writeValueAsString(requestBody);
         httpPost.setEntity(new StringEntity(jsonRequestBody));
 
-        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
-            int statusCode = response.getStatusLine().getStatusCode();
+        return httpClient.execute(httpPost, response -> {
+            int statusCode = response.getCode();
             if (statusCode != 200) {
                 throw new IOException("Failed to call parser service. Status code: " + statusCode);
             }
             String jsonResponse = EntityUtils.toString(response.getEntity());
             return objectMapper.readValue(jsonResponse, ParseResultDto.class);
-        }
+        });
     }
 }

--- a/config-repo/parser-service.properties
+++ b/config-repo/parser-service.properties
@@ -1,0 +1,8 @@
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.info.title=TDT SQL Scan - Parser Service API
+springdoc.info.version=v0.1.0
+springdoc.info.description=API para el análisis sintáctico de scripts SQL y BTEQ.
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9000
+server.port=8080

--- a/config-repo/user-service.properties
+++ b/config-repo/user-service.properties
@@ -1,0 +1,43 @@
+# ===============================================================
+# = APPLICATION CONFIGURATION
+# ===============================================================
+app.name=Data Flow Visualizer
+app.email.registration.subject=Account Verification for ${app.name}
+app.email.reset.subject=Password Reset Request for ${app.name}
+
+
+# Forwarded Headers Strategy
+server.forward-headers-strategy=native
+
+# H2 Database Configuration
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.h2.console.settings.web-allow-others=true
+
+# Datasource Configuration
+spring.datasource.url=jdbc:h2:file:./data/testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA Configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+# Mail Server Configuration (placeholders - PLEASE CONFIGURE)
+spring.mail.from=noreply@example.com
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=your-email@example.com
+spring.mail.password=your-password
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+# TinyMCE Configuration
+tinymce.api.key=${TINYMCE_API_KEY:no-api-key}
+
+# ===============================================================
+# = CLIENT CONFIGURATION
+# ===============================================================
+client.parser-service.url=http://parser-service:8080

--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>config-server</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>config-server</name>
+    <description>Spring Cloud Config Server</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-config-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/config-server/src/main/java/com/example/configserver/ConfigServerApplication.java
+++ b/config-server/src/main/java/com/example/configserver/ConfigServerApplication.java
@@ -1,0 +1,15 @@
+package com.example.configserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ConfigServerApplication.class, args);
+    }
+
+}

--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8888
+spring.cloud.config.server.git.uri=./config-repo

--- a/parser-service/pom.xml
+++ b/parser-service/pom.xml
@@ -20,9 +20,26 @@
     <properties>
         <java.version>17</java.version>
         <antlr.version>4.13.1</antlr.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <module>app-cli</module>
     <module>app-web</module>
     <module>parser-service</module>
+    <module>config-server</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This change introduces the initial setup for the Spring Cloud Config Server.

- Creates a new `config-server` Spring Boot module with the necessary dependencies.
- Creates a `config-repo` directory to act as the backend for the config server.
- Populates `config-repo` with `parser-service.properties` and `user-service.properties`.
- Initializes `config-repo` as a Git repository and commits the initial configuration files.

Note: The refactoring of the `parser-service` to use the config server is incomplete due to persistent tooling errors that prevented further file modifications. I've been instructed to submit the code in its current state. The out-of-scope change to `ParserServiceClient.java` was necessary to make the project build and is included in this commit.