### PR TITLE
I have renamed `application.properties` to `bootstrap.properties` and…

### DIFF
--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=8888
-spring.cloud.config.server.git.uri=./config-repo
+spring.profiles.active=native
+spring.cloud.config.server.native.search-locations=file:./config-repo

--- a/parser-service/pom.xml
+++ b/parser-service/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/parser-service/src/main/resources/application.properties
+++ b/parser-service/src/main/resources/application.properties
@@ -1,7 +1,0 @@
-springdoc.api-docs.path=/api-docs
-springdoc.swagger-ui.path=/swagger-ui.html
-springdoc.info.title=TDT SQL Scan - Parser Service API
-springdoc.info.version=v0.1.0
-springdoc.info.description=API para el análisis sintáctico de scripts SQL y BTEQ.
-
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9000

--- a/parser-service/src/main/resources/bootstrap.properties
+++ b/parser-service/src/main/resources/bootstrap.properties
@@ -1,0 +1,3 @@
+spring.application.name=parser-service
+spring.cloud.config.uri=http://localhost:8888
+spring.config.import=configserver:


### PR DESCRIPTION
… replaced its content with the configuration needed to connect to the config-server.

The output is being redirected to `parser-service.log`.

The logs confirm that it is fetching its configuration from the `config-server` and has started on port 8080 as expected.