### PR TITLE
feat: Implement Basic API Gateway with Spring Cloud Gateway

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.tdtsqlscan</groupId>
+    <artifactId>api-gateway</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>api-gateway</name>
+    <description>API Gateway for TDT SQL Scan</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/api-gateway/src/main/java/com/tdtsqlscan/apigateway/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/com/tdtsqlscan/apigateway/ApiGatewayApplication.java
@@ -1,0 +1,13 @@
+package com.tdtsqlscan.apigateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ApiGatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ApiGatewayApplication.class, args);
+    }
+
+}

--- a/api-gateway/src/main/resources/bootstrap.properties
+++ b/api-gateway/src/main/resources/bootstrap.properties
@@ -1,0 +1,2 @@
+spring.application.name=api-gateway
+spring.cloud.config.uri=http://localhost:8888

--- a/config-repo/api-gateway.properties
+++ b/config-repo/api-gateway.properties
@@ -1,0 +1,14 @@
+# Puerto para el Gateway
+server.port=8080
+
+# Rutas
+spring.cloud.gateway.routes[0].id=user-service-route
+spring.cloud.gateway.routes[0].uri=lb://user-service
+spring.cloud.gateway.routes[0].predicates[0]=Path=/api/v1/users/**, /api/v1/auth/**
+
+spring.cloud.gateway.routes[1].id=parser-service-route
+spring.cloud.gateway.routes[1].uri=lb://parser-service
+spring.cloud.gateway.routes[1].predicates[0]=Path=/api/v1/parse/**
+
+spring.cloud.discovery.client.simple.instances.user-service[0].uri=http://localhost:8081
+spring.cloud.discovery.client.simple.instances.parser-service[0].uri=http://localhost:8082

--- a/config-repo/parser-service.properties
+++ b/config-repo/parser-service.properties
@@ -5,4 +5,4 @@ springdoc.info.version=v0.1.0
 springdoc.info.description=API para el análisis sintáctico de scripts SQL y BTEQ.
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9000
-server.port=8080
+server.port=8082

--- a/config-repo/user-service.properties
+++ b/config-repo/user-service.properties
@@ -49,3 +49,4 @@ client.parser-service.url=http://parser-service:8080
 # This is a placeholder key and is NOT secure.
 jwt.secret=dGhpcy1pcy1hLXNlY3JldC1rZXktZm9yLWp3dC1hdXRoZW50aWNhdGlvbi1hbmQtbmVlZHMtdG8tYmUtcmVwbGFjZWQtd2l0aC1hLXN0cm9uZy1rZXkK
 jwt.expiration=3600000
+server.port=8081

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <module>app-web</module>
     <module>parser-service</module>
     <module>config-server</module>
+    <module>api-gateway</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This commit introduces a new `api-gateway` microservice to act as a single entry point for the platform.

Key changes include:
- Creation of the `api-gateway` Spring Boot project with Spring Cloud Gateway.
- Centralized configuration for routes in the `config-repo`, directing traffic to `user-service` and `parser-service`.
- Simple service discovery setup for local development.
- Adjustment of service ports to prevent conflicts:
  - `api-gateway`: 8080
  - `user-service`: 8081
  - `parser-service`: 8082
- Connection of the `api-gateway` to the `config-server`.