### PR TITLE
feat(gateway): Implement JWT validation

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api-gateway/src/main/java/com/tdtsqlscan/apigateway/config/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/tdtsqlscan/apigateway/config/AuthenticationFilter.java
@@ -1,0 +1,25 @@
+package com.tdtsqlscan.apigateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class AuthenticationFilter {
+
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchange -> exchange
+                        .pathMatchers("/api/v1/auth/**", "/api/v1/users/**").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}

--- a/config-repo/api-gateway.properties
+++ b/config-repo/api-gateway.properties
@@ -12,3 +12,5 @@ spring.cloud.gateway.routes[1].predicates[0]=Path=/api/v1/parse/**
 
 spring.cloud.discovery.client.simple.instances.user-service[0].uri=http://localhost:8081
 spring.cloud.discovery.client.simple.instances.parser-service[0].uri=http://localhost:8082
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8081


### PR DESCRIPTION
This change introduces JWT validation at the API Gateway level.

- Adds `spring-boot-starter-security` and `spring-boot-starter-oauth2-resource-server` dependencies to the `api-gateway` module.
- Configures the API Gateway as an OAuth2 Resource Server by setting the `issuer-uri` in `api-gateway.properties`.
- Implements a `SecurityWebFilterChain` bean that defines public routes (`/api/v1/auth/**`, `/api/v1/users/**`) and secures all other routes.
- The gateway now intercepts incoming requests, validates the `Authorization: Bearer` token, and only forwards the request to downstream services if the token is valid.

This centralizes authentication logic at the perimeter of the system, simplifying backend services and adhering to a Zero Trust security model.