### PR TITLE
feat: Make homepage and parser publicly accessible

### DIFF
--- a/api-gateway/src/main/java/com/tdtsqlscan/apigateway/config/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/tdtsqlscan/apigateway/config/AuthenticationFilter.java
@@ -17,6 +17,7 @@ public class AuthenticationFilter {
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .authorizeExchange(exchange -> exchange
                         .pathMatchers("/api/v1/auth/**", "/api/v1/users/**").permitAll()
+                        .pathMatchers("/api/v1/parse/**").permitAll()
                         .anyExchange().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     environment:
       SPRING_APPLICATION_NAME: parser-service
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
+      SPRING_PROFILES_ACTIVE: dev-unsecured
     depends_on:
       config-server:
         condition: service_healthy

--- a/frontend-spa/src/routes/index.tsx
+++ b/frontend-spa/src/routes/index.tsx
@@ -9,13 +9,12 @@ export const routes: RouteObject[] = [
     element: <LoginPage />,
   },
   {
+    path: '/',
+    element: <HomePage />,
+  },
+  {
     element: <ProtectedRoute />,
-    children: [
-      {
-        path: '/',
-        element: <HomePage />,
-      },
-    ],
+    children: [],
   },
 ];
 


### PR DESCRIPTION
This commit implements the necessary changes to make the application's home page and SQL parsing functionality public, removing the need for user authentication.

The changes include:
- Modifying the frontend routing to make the HomePage a public route.
- Updating the API Gateway security configuration to permit all requests to the parsing endpoints.
- Activating the 'dev-unsecured' Spring profile in the parser-service to disable token validation.